### PR TITLE
ci: add design-review skill and fix doc consistency issues

### DIFF
--- a/.github/skills/design-review/SKILL.md
+++ b/.github/skills/design-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: design-review
+description: 'Review nostos design documents (concept.md and architecture.md) for internal consistency, stale references, and completeness. Use when design docs have been updated and need a consistency pass, or when a new design section has been added.'
+---
+
+# Design Review Skill
+
+Review `docs/concept.md` and `docs/architecture.md` for internal
+consistency after changes. Catches stale references, contradictions,
+and missing updates that arise when a new design section is added but
+existing sections still reflect the old model.
+
+USE FOR: "review the design docs", "check concept.md for consistency",
+"are the docs consistent?", "design review", "doc consistency check"
+
+DO NOT USE FOR: code review, PR review, implementation review
+
+## Checks
+
+Read both documents fully, then check for:
+
+### 1. Cross-document consistency
+
+- State file schemas in concept.md and architecture.md must agree
+  (field names, types, example values)
+- Module structure in architecture.md must cover all commands described
+  in concept.md's "Proposed UX" section
+- Anything listed as "deferred" in architecture.md should not appear as
+  MVP-required in concept.md
+
+### 2. Internal consistency within concept.md
+
+- **Singular vs plural repo language** — the multi-repo section
+  describes multiple repos, but earlier sections may still say "the
+  repo" in ways that contradict multi-repo support
+- **CLI command references** — every `nostos <command>` shown in
+  examples must be described in the "Proposed UX" section or in a
+  design section. No invented commands.
+- **state.toml examples** — all `state.toml` snippets must include
+  `[machine]` and should reference `[[repo]]` (or forward-reference to
+  the multi-repo section) where appropriate
+- **Resolved decisions** — each resolved decision should be consistent
+  with the detailed design sections it summarizes. If a design section
+  has evolved, the resolved decision entry may be stale.
+- **Examples match described behavior** — command output shown in usage
+  examples must match the semantics described in the design (e.g., if
+  merge is last-repo-wins, examples shouldn't show first-repo-wins)
+
+### 3. Internal consistency within architecture.md
+
+- Module structure should list all CLI subcommands that concept.md
+  describes (even if marked post-MVP)
+- Config schema fields must match what concept.md's examples use
+- Dependency table should cover libraries needed by described features
+
+### 4. Completeness
+
+- Every major design concept in concept.md should have a corresponding
+  entry in architecture.md (module, schema field, or deferred note)
+- Forward and backward references between sections should resolve
+  (anchor links, section names)
+- New design sections should be mentioned in the resolved decisions if
+  they settle a previously open question
+
+## Output format
+
+Report issues as a numbered list with:
+
+- **Severity**: High (contradicts), Medium (misleads), Low (imprecise)
+- **Location**: file and line number(s)
+- **Issue**: what's wrong
+- **Fix**: concrete suggestion
+
+Group by severity (High first). Skip style and formatting issues —
+only report substantive problems.
+
+## Workflow
+
+1. Read `docs/concept.md` fully
+2. Read `docs/architecture.md` fully
+3. Run all checks above
+4. Present findings to the user, grouped by severity
+5. Ask whether to fix all, fix high/medium only, or just report

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,9 +43,12 @@ src/
 ├── cli/                 ← command-line interface
 │   ├── mod.rs           ← clap app definition
 │   ├── apply.rs         ← nostos apply
+│   ├── init.rs          ← nostos init (post-MVP)
 │   ├── plan.rs          ← nostos plan
 │   ├── repo.rs          ← nostos repo add/remove/list (post-MVP)
-│   └── status.rs        ← nostos status
+│   ├── status.rs        ← nostos status
+│   ├── sync.rs          ← nostos sync (post-MVP)
+│   └── track.rs         ← nostos track (post-MVP)
 ├── config/              ← configuration parsing and merging
 │   ├── mod.rs           ← top-level Config struct
 │   ├── dotfiles.rs      ← dotfile config types

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -896,7 +896,7 @@ nostos plan
 # Add a new dotfile to be managed
 nostos track ~/.config/starship.toml
 
-# Sync: commit local changes, pull remote changes, apply
+# Sync: commit local changes, pull remote changes, push, apply
 nostos sync
 
 # Show current machine identity, platform, and detected package managers
@@ -1069,14 +1069,16 @@ nostos plan
 nostos apply
 #   ✓ Installed zoxide via brew
 
-# Commit and push so other machines pick it up
+# Commit, pull, push, then re-apply so other machines pick it up
 nostos sync
 #   Committed: "Add zoxide"
+#   Pulled from origin/main — already up to date
 #   Pushed to origin/main
+#   Applied — no changes
 ```
 
-On your next machine, `nostos sync` (or `nostos apply` after a git pull)
-installs zoxide using whatever package manager is available there.
+On your next machine, `nostos sync` pulls the change and applies it,
+installing zoxide using whatever package manager is available there.
 
 ### Handling a tool with different package names
 
@@ -1166,6 +1168,7 @@ ignored by git.
 │         │   Layering / Merge    │           │
 │         │  per-repo: base →     │           │
 │         │    platform → machine │           │
+│         │    (post-MVP)         │           │
 │         │  cross-repo: ordered  │           │
 │         │    merge (post-MVP)   │           │
 │         └───────────────────────┘           │
@@ -1313,6 +1316,10 @@ id = "work-macbook"
 ".bashrc" = { hash = "sha256:abc123...", timestamp = "2026-04-26T20:00:00Z" }
 ".config/starship.toml" = { hash = "sha256:def456...", timestamp = "2026-04-25T10:30:00Z" }
 ```
+
+When multiple repos are configured, applied entries also include a
+`source` field for repo attribution. See
+[State file additions](#state-file-additions).
 
 On `nostos apply`, for each managed file, there are four possible states:
 
@@ -1485,9 +1492,9 @@ show provenance and shadowing.
 **`nostos plan`** shows the unified view with source attribution — which
 repo each file/tool comes from, and whether any files are shadowed.
 
-**`nostos sync`** syncs each repo independently (commit, push, pull) in
-order. Partial failures are reported per-repo; a failure in one repo
-does not prevent syncing the others.
+**`nostos sync`** syncs each repo independently (commit, pull, push,
+apply) in order. Partial failures are reported per-repo; a failure in
+one repo does not prevent syncing the others.
 
 **`nostos status`** shows all repos, their order, and their git status.
 


### PR DESCRIPTION
Adds a repo-level `design-review` skill and uses it to fix consistency issues in the design docs.

## New: design-review skill

`.github/skills/design-review/SKILL.md` — a Copilot skill that reviews `concept.md` and `architecture.md` for:
- Cross-document schema and module consistency
- Stale singular-repo language
- Invented CLI commands
- state.toml example completeness
- Resolved decisions staleness

## Doc fixes found by the skill

1. **Canonicalize sync order** — all three locations (Proposed UX, usage example, multi-repo section) now consistently say commit → pull → push → apply
2. **Label per-repo layering as post-MVP** in the architecture sketch (matches architecture.md’s deferred list)
3. **Add missing CLI modules** to architecture.md — `init.rs`, `sync.rs`, `track.rs` (all post-MVP)
4. **Add forward-reference** to multi-repo state additions after the second state.toml snippet in conflict detection