### PR TITLE
fix(reconcile): stream files through SHA-256 hasher (#7)

### DIFF
--- a/src/reconcile/dotfiles.rs
+++ b/src/reconcile/dotfiles.rs
@@ -320,10 +320,22 @@ fn expand_tilde(path: &str) -> Result<PathBuf, Error> {
 }
 
 /// Hash a file's contents using SHA-256, returning `sha256:<hex>`.
+///
+/// Streams the file through the hasher with a fixed-size buffer so that large
+/// files do not cause RSS to grow proportionally to file size.
 fn hash_file(path: &Path) -> Result<String, std::io::Error> {
-    let content = std::fs::read(path)?;
-    let digest = Sha256::digest(&content);
-    Ok(format!("sha256:{:x}", digest))
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
 /// Generate a backup path for a conflicting file.
@@ -791,5 +803,33 @@ mod tests {
         let result = expand_tilde("~/Documents").unwrap();
         let home = dirs::home_dir().expect("home dir should exist in test");
         assert_eq!(result, home.join("Documents"));
+    }
+
+    #[test]
+    fn hash_file_streaming_matches_one_shot_on_large_input() {
+        // 64 KiB + 123 bytes deliberately straddles the 8 KiB read buffer with
+        // a partial final read, exercising the EOF path in hash_file.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("big.bin");
+        let mut content = Vec::with_capacity(64 * 1024 + 123);
+        for i in 0..(64 * 1024 + 123) {
+            content.push((i % 256) as u8);
+        }
+        fs::write(&path, &content).unwrap();
+
+        let streamed = hash_file(&path).unwrap();
+        let expected = format!("sha256:{:x}", Sha256::digest(&content));
+        assert_eq!(streamed, expected);
+    }
+
+    #[test]
+    fn hash_file_handles_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("empty.bin");
+        fs::write(&path, b"").unwrap();
+
+        let hashed = hash_file(&path).unwrap();
+        let expected = format!("sha256:{:x}", Sha256::digest([]));
+        assert_eq!(hashed, expected);
     }
 }


### PR DESCRIPTION
Closes #7.

## Problem

\`hash_file\` in \`src/reconcile/dotfiles.rs\` previously did:

\`\`\`rust
let content = std::fs::read(path)?;
let digest = Sha256::digest(&content);
\`\`\`

That loads the entire file into memory before hashing, so RSS grows
proportionally with file size. Most dotfiles are small, but a large
binary config or accidentally-included file in the dotfiles tree
could spike memory unnecessarily.

## Fix

Stream the file through the hasher with a fixed 8 KiB stack buffer:

\`\`\`rust
let mut file = File::open(path)?;
let mut hasher = Sha256::new();
let mut buffer = [0u8; 8192];
loop {
    let n = file.read(&mut buffer)?;
    if n == 0 { break; }
    hasher.update(&buffer[..n]);
}
\`\`\`

Memory now stays bounded at the buffer size regardless of input.

## Tests

- \`hash_file_streaming_matches_one_shot_on_large_input\` — hashes a
  64 KiB + 123-byte payload (deliberately not aligned to the buffer)
  and asserts the result equals \`Sha256::digest(&content)\` formatted
  with the same \`sha256:{:x}\` prefix. Catches partial-final-read
  bugs.
- \`hash_file_handles_empty_file\` — confirms the empty-file digest
  matches \`Sha256::digest([])\`.

## Quality gates

- \`cargo clippy --all-targets\` — clean.
- \`cargo test\` — all tests pass (with 2 new lib tests added).