### PR TITLE
fix(state): use unique tempfile for atomic state save (#5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ dirs = "6"
 miette = { version = "7", features = ["fancy"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
+tempfile = "3"
 thiserror = "2"
 toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
-tempfile = "3"

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -59,22 +59,39 @@ impl State {
         self.save_to(&path)
     }
 
-    /// Save state to a specific path using atomic write (write to temp
-    /// file, then rename).
+    /// Save state to a specific path using atomic write.
+    ///
+    /// Writes to a uniquely-named temporary file in the same directory and
+    /// then renames it over `path`. Using a unique temp file (rather than a
+    /// fixed `state.toml.tmp`) prevents two concurrent writers — e.g.,
+    /// nostos invocations running against different repos in parallel shells
+    /// — from clobbering each other's temp data.
     pub fn save_to(&self, path: &Path) -> Result<(), Error> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(Error::Write)?;
-        }
+        use std::io::Write;
+
+        let parent = parent_or_dot(path);
+        std::fs::create_dir_all(parent).map_err(Error::Write)?;
 
         let content = toml::to_string_pretty(self).expect("state should always serialize");
 
-        // Atomic write: write to a temp file in the same directory, then rename
-        let tmp_path = path.with_extension("toml.tmp");
-        std::fs::write(&tmp_path, &content).map_err(Error::Write)?;
-        std::fs::rename(&tmp_path, path).map_err(Error::Write)?;
+        let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(Error::Write)?;
+        tmp.write_all(content.as_bytes()).map_err(Error::Write)?;
+        tmp.persist(path).map_err(|e| Error::Write(e.error))?;
 
         Ok(())
     }
+}
+
+/// Resolve the directory we should place the temp file in.
+///
+/// `Path::parent()` returns `Some("")` for a bare filename like
+/// `state.toml` and `None` for the root, so naive use of the result would
+/// hand `tempfile::NamedTempFile::new_in` an empty path. Fall back to "."
+/// in either case.
+fn parent_or_dot(path: &Path) -> &Path {
+    path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
 }
 
 /// Get the default state file path for this platform.
@@ -165,9 +182,16 @@ mod tests {
         let state = State::default();
         state.save_to(&path).expect("save");
 
-        let tmp = path.with_extension("toml.tmp");
-        assert!(!tmp.exists(), "temp file should be cleaned up");
-        assert!(path.exists(), "state file should exist");
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "parent dir should contain only state.toml, got {entries:?}"
+        );
+        assert_eq!(entries[0], "state.toml");
     }
 
     #[test]
@@ -211,5 +235,86 @@ mod tests {
         state.save_to(&path).expect("save");
         let loaded = State::load_from(&path).expect("load");
         assert_eq!(loaded.applied.len(), 50);
+    }
+
+    #[test]
+    fn save_to_bare_filename_uses_current_dir() {
+        // The parent helper must resolve a bare filename to "."; otherwise
+        // NamedTempFile::new_in would fail on an empty path. We verify the
+        // helper directly to avoid mutating process-global cwd.
+        assert_eq!(parent_or_dot(Path::new("state.toml")), Path::new("."));
+        assert_eq!(parent_or_dot(Path::new("./state.toml")), Path::new("."));
+        assert_eq!(parent_or_dot(Path::new("a/state.toml")), Path::new("a"));
+        assert_eq!(parent_or_dot(Path::new("/")), Path::new("."));
+    }
+
+    #[test]
+    fn concurrent_writes_dont_corrupt_state() {
+        // Many threads writing distinct, valid State payloads to the same
+        // path should never leave a half-written or interleaved file. With
+        // unique tempfiles, the file always contains exactly one writer's
+        // payload (last writer wins).
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.toml");
+        const N: usize = 8;
+
+        let barrier = Arc::new(Barrier::new(N));
+        let path = Arc::new(path);
+
+        // Pre-build the expected serialized content for each thread so we can
+        // match the final on-disk file against one of them exactly.
+        let expected_contents: Vec<String> = (0..N)
+            .map(|i| {
+                let mut state = State::default();
+                state.applied.insert(
+                    format!(".file{i}"),
+                    AppliedEntry {
+                        hash: format!("sha256:thread{i}"),
+                        timestamp: chrono::DateTime::parse_from_rfc3339(
+                            "2026-04-26T20:00:00Z",
+                        )
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    },
+                );
+                toml::to_string_pretty(&state).unwrap()
+            })
+            .collect();
+
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let barrier = Arc::clone(&barrier);
+                let path = Arc::clone(&path);
+                let expected = expected_contents[i].clone();
+                std::thread::spawn(move || {
+                    // Reconstruct the same State the expected content was built from.
+                    let state: State = toml::from_str(&expected).unwrap();
+                    barrier.wait();
+                    state.save_to(&path).expect("concurrent save should succeed");
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("worker thread should not panic");
+        }
+
+        // Final file must parse and exactly equal one of the writers' payloads.
+        let final_content = std::fs::read_to_string(path.as_path()).unwrap();
+        let _: State = toml::from_str(&final_content).expect("file should parse");
+        assert!(
+            expected_contents.iter().any(|e| e == &final_content),
+            "final file must match one writer's content exactly; got {final_content:?}"
+        );
+
+        // Parent dir holds only the state file — no leaked tempfiles.
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries.len(), 1, "leaked entries: {entries:?}");
+        assert_eq!(entries[0], "state.toml");
     }
 }


### PR DESCRIPTION
Closes #5.

## Problem

\`State::save_to\` wrote to a fixed \`state.toml.tmp\` next to the
target before renaming. Two concurrent nostos processes saving the
same state file (e.g., running against different repos in parallel
shells under one user) raced on that path. Possible outcomes
included a corrupt or truncated tempfile and one process's payload
silently overwriting another's.

## Fix

Switch to \`tempfile::NamedTempFile::new_in(parent)\` plus
\`.persist(path)\`. Every writer gets its own randomized temp name,
and \`persist\` atomically replaces the destination — including
correct overwrite semantics on Windows, which the previous
\`std::fs::rename\` did not portably guarantee.

Other changes:

- Promote \`tempfile\` from a dev-dependency to a regular dependency.
- Extract a \`parent_or_dot\` helper so a bare-filename target (where
  \`Path::parent()\` returns \`Some(\"\")\` rather than \`None\`)
  resolves correctly to \`.\`.

## Tests

- \`atomic_write_no_temp_file_left\` — rewritten to scan the parent
  dir and assert \`state.toml\` is the only entry left (the old
  fixed-name check is no longer meaningful with random temp names).
- \`save_to_bare_filename_uses_current_dir\` — unit-tests the
  \`parent_or_dot\` helper across bare, \`./\`, nested, and root
  inputs (avoids the parallel-test landmine of mutating
  \`current_dir\`).
- \`concurrent_writes_dont_corrupt_state\` — a Barrier-coordinated
  8-thread test where each thread serializes and writes a *distinct*
  valid \`State\`. Asserts:
  1. no panics,
  2. final file parses,
  3. final content matches **one** writer's serialized payload
     exactly (no interleaved bytes),
  4. parent dir contains only \`state.toml\` (no leaked tempfiles).

## Out of scope

Durability / fsync. \`NamedTempFile::persist\` does not sync the
file or its parent directory, and the previous code did not either.
Adding partial fsync would only add false confidence; if we want
crash-durability we should sync both the temp file and the parent
dir as a separate change.

## Quality gates

- \`cargo clippy --all-targets\` — clean.
- \`cargo test\` — all tests pass (with 3 new state tests).