### PR TITLE
feat: minimum viable release (v0.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 A cross-platform dev environment sync tool. Manage your dotfiles with
 conflict detection, safe backups, and a simple TOML config.
 
+## Installation
+
+```shell
+cargo install --path .
+```
+
+Requires Rust 1.95+ (edition 2024).
+
 ## Quick start
 
 1. Create a repo with a `dotfiles/` directory containing your config files
@@ -24,12 +32,25 @@ conflict detection, safe backups, and a simple TOML config.
    [dotfiles]
    source = "dotfiles/"
    target = "~"
+
+   # Declare tools you need — not yet installed by nostos, but the config
+   # is validated now and will "just work" when tool installation ships.
+   [[tool]]
+   name = "ripgrep"
+   bin = "rg"
+   install.brew = "ripgrep"
+   install.apt = "ripgrep"
+
+   [[hook]]
+   name = "post-setup"
+   run = "scripts/post-apply.sh"
+   when = "post-apply"
    ```
 
-3. Run nostos from within the repo:
+3. Run nostos:
 
    ```shell
-   # Check platform info and config validity
+   # Check platform info, available package managers, and config validity
    nostos status
 
    # Preview what would happen (dry run)
@@ -37,6 +58,13 @@ conflict detection, safe backups, and a simple TOML config.
 
    # Apply dotfiles to your home directory
    nostos apply
+   ```
+
+   After the first `apply`, nostos remembers your repo location. You can
+   run commands from anywhere, or use `--repo <path>` to override:
+
+   ```shell
+   nostos --repo ~/dotfiles plan
    ```
 
 ## How it works
@@ -57,14 +85,26 @@ conflict detection, safe backups, and a simple TOML config.
 
 ## Commands
 
-| Command  | Description                              | Exit codes           |
-|----------|------------------------------------------|----------------------|
-| `status` | Show platform info and config validity   | 0, 3, 4 (platform)  |
-| `plan`   | Dry-run showing all planned actions      | 0, 3 (config error)  |
-| `apply`  | Apply dotfiles, save state               | 0, 3, 5 (warnings)   |
+| Command  | Description                                        | Exit codes           |
+|----------|----------------------------------------------------|----------------------|
+| `status` | Platform, managers, machine identity, config check | 0, 3, 4 (platform)  |
+| `plan`   | Dry-run showing all planned actions                | 0, 3 (config error)  |
+| `apply`  | Apply dotfiles, save state                         | 0, 3, 5 (warnings)   |
 
 Exit code 5 means some files were skipped (local modifications detected)
 but other files were applied successfully.
+
+### Global flags
+
+| Flag            | Description                                      |
+|-----------------|--------------------------------------------------|
+| `--repo <path>` | Override the repo/config location                |
+
+### Repo resolution order
+
+1. `--repo` flag (explicit)
+2. Path stored in state from a previous `apply`
+3. Current working directory
 
 ## Why "nostos"?
 
@@ -83,6 +123,22 @@ cargo build
 cargo test
 cargo clippy --all-targets
 ```
+
+## Status
+
+**v0.1.0** — Reliable dotfile management with forward-compatible config.
+
+What works today:
+- Dotfile sync with conflict detection and safe backups
+- Full config schema validation (tools, hooks, files, preferences)
+- Cross-platform (Linux, macOS, Windows)
+- Package manager discovery
+- Machine identity and repo path tracking
+
+Coming next:
+- Tool installation (the config schema is already validated)
+- Hook execution
+- `nostos init` / `nostos sync` (git operations)
 
 ## License
 

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -15,10 +15,7 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
 
     let mut state = State::load().unwrap_or_default();
     state.ensure_machine_identity();
-    let repo_root = config_path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| std::env::current_dir().expect("cannot determine repo root"));
+    let repo_root = config::repo_root_from_config(&config_path);
 
     let report = match reconcile::apply(&cfg, &mut state, &repo_root) {
         Ok(r) => r,

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::reconcile::dotfiles::{self, DotfileAction};
+use crate::reconcile::{self, dotfiles::DotfileAction};
 use crate::state::State;
 use std::process::ExitCode;
 
@@ -12,18 +12,10 @@ pub fn run() -> anyhow::Result<ExitCode> {
         }
     };
 
-    let dotfiles_config = match cfg.dotfiles {
-        Some(dc) => dc,
-        None => {
-            eprintln!("Error: missing required [dotfiles] section in nostos.toml");
-            return Ok(ExitCode::from(3));
-        }
-    };
-
     let mut state = State::load().unwrap_or_default();
     let repo_root = std::env::current_dir()?;
 
-    let report = match dotfiles::apply(&dotfiles_config, &mut state, &repo_root) {
+    let report = match reconcile::apply(&cfg, &mut state, &repo_root) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {e}");
@@ -31,36 +23,46 @@ pub fn run() -> anyhow::Result<ExitCode> {
         }
     };
 
-    for action in &report.actions {
-        match action {
-            DotfileAction::NewFile { target, .. } => {
-                println!("  ✓ Copied → {}", target.display());
+    // Print dotfiles results
+    if let Some(ref dotfiles_report) = report.dotfiles {
+        for action in &dotfiles_report.actions {
+            match action {
+                DotfileAction::NewFile { target, .. } => {
+                    println!("  ✓ Copied → {}", target.display());
+                }
+                DotfileAction::UpToDate { target } => {
+                    println!("  ✓ {} — up to date", display_target(target));
+                }
+                DotfileAction::CleanUpdate { target, .. } => {
+                    println!("  ✓ Updated → {}", target.display());
+                }
+                DotfileAction::LocalModification { target } => {
+                    println!(
+                        "  ⚠ {} — local modification, skipped",
+                        display_target(target)
+                    );
+                }
+                DotfileAction::Conflict { target, backup, .. } => {
+                    println!(
+                        "  ⚠ Backed up {} → {}",
+                        display_target(target),
+                        backup.display()
+                    );
+                    println!("  ✓ Updated → {}", target.display());
+                }
             }
-            DotfileAction::UpToDate { target } => {
-                println!("  ✓ {} — up to date", display_target(target));
-            }
-            DotfileAction::CleanUpdate { target, .. } => {
-                println!("  ✓ Updated → {}", target.display());
-            }
-            DotfileAction::LocalModification { target } => {
-                println!(
-                    "  ⚠ {} — local modification, skipped",
-                    display_target(target)
-                );
-            }
-            DotfileAction::Conflict { target, backup, .. } => {
-                println!(
-                    "  ⚠ Backed up {} → {}",
-                    display_target(target),
-                    backup.display()
-                );
-                println!("  ✓ Updated → {}", target.display());
-            }
+        }
+
+        for err in &dotfiles_report.errors {
+            eprintln!("  ✗ {err}");
         }
     }
 
-    for err in &report.errors {
-        eprintln!("  ✗ {err}");
+    // Print pending phase warnings
+    for phase in &report.pending_phases {
+        if let Some(ref reason) = phase.skipped_reason {
+            println!("⚠ {reason}");
+        }
     }
 
     // Save updated state
@@ -69,7 +71,7 @@ pub fn run() -> anyhow::Result<ExitCode> {
     }
 
     // Exit code 5 if there were warnings (local mods, conflicts)
-    if report.has_warnings() || !report.errors.is_empty() {
+    if report.has_warnings() || report.has_errors() {
         Ok(ExitCode::from(5))
     } else {
         Ok(ExitCode::SUCCESS)
@@ -81,3 +83,4 @@ fn display_target(path: &std::path::Path) -> String {
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_else(|| path.display().to_string())
 }
+

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -14,6 +14,7 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     };
 
     let mut state = State::load().unwrap_or_default();
+    state.ensure_machine_identity();
     let repo_root = config_path
         .parent()
         .map(|p| p.to_path_buf())

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -1,10 +1,11 @@
 use crate::config;
 use crate::reconcile::{self, dotfiles::DotfileAction};
 use crate::state::State;
+use std::path::Path;
 use std::process::ExitCode;
 
-pub fn run() -> anyhow::Result<ExitCode> {
-    let (_path, cfg) = match config::find_config() {
+pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
+    let (config_path, cfg) = match config::find_config_with_repo(repo) {
         Ok(result) => result,
         Err(e) => {
             eprintln!("{e}");
@@ -13,7 +14,10 @@ pub fn run() -> anyhow::Result<ExitCode> {
     };
 
     let mut state = State::load().unwrap_or_default();
-    let repo_root = std::env::current_dir()?;
+    let repo_root = config_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::env::current_dir().expect("cannot determine repo root"));
 
     let report = match reconcile::apply(&cfg, &mut state, &repo_root) {
         Ok(r) => r,
@@ -63,6 +67,11 @@ pub fn run() -> anyhow::Result<ExitCode> {
         if let Some(ref reason) = phase.skipped_reason {
             println!("⚠ {reason}");
         }
+    }
+
+    // Store repo path in state if not already set
+    if state.repo_path().is_none() {
+        state.set_repo_path(repo_root.to_string_lossy().to_string());
     }
 
     // Save updated state

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,10 @@ use std::process::ExitCode;
 #[derive(Parser)]
 #[command(name = "nostos", about = "Welcome home, hero", version)]
 pub struct Cli {
+    /// Path to the nostos repo (overrides stored path and current directory)
+    #[arg(long, global = true)]
+    pub repo: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -25,6 +29,8 @@ pub enum Command {
 
 /// Run the CLI. Returns an ExitCode.
 pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
+    // TODO: use cli.repo once --repo support is wired through
+    let _repo = cli.repo.as_deref();
     match cli.command {
         Command::Status => status::run(),
         Command::Plan => plan::run(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,11 +29,10 @@ pub enum Command {
 
 /// Run the CLI. Returns an ExitCode.
 pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
-    // TODO: use cli.repo once --repo support is wired through
-    let _repo = cli.repo.as_deref();
+    let repo = cli.repo.as_deref();
     match cli.command {
-        Command::Status => status::run(),
-        Command::Plan => plan::run(),
-        Command::Apply => apply::run(),
+        Command::Status => status::run(repo),
+        Command::Plan => plan::run(repo),
+        Command::Apply => apply::run(repo),
     }
 }

--- a/src/cli/plan.rs
+++ b/src/cli/plan.rs
@@ -14,10 +14,7 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     };
 
     let state = State::load().unwrap_or_default();
-    let repo_root = config_path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| std::env::current_dir().expect("cannot determine repo root"));
+    let repo_root = config::repo_root_from_config(&config_path);
 
     let report = match reconcile::plan(&cfg, &state, &repo_root) {
         Ok(r) => r,

--- a/src/cli/plan.rs
+++ b/src/cli/plan.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::reconcile::dotfiles::{self, DotfileAction};
+use crate::reconcile::{self, dotfiles::DotfileAction};
 use crate::state::State;
 use std::process::ExitCode;
 
@@ -12,18 +12,10 @@ pub fn run() -> anyhow::Result<ExitCode> {
         }
     };
 
-    let dotfiles_config = match cfg.dotfiles {
-        Some(dc) => dc,
-        None => {
-            eprintln!("Error: missing required [dotfiles] section in nostos.toml");
-            return Ok(ExitCode::from(3));
-        }
-    };
-
     let state = State::load().unwrap_or_default();
     let repo_root = std::env::current_dir()?;
 
-    let report = match dotfiles::plan(&dotfiles_config, &state, &repo_root) {
+    let report = match reconcile::plan(&cfg, &state, &repo_root) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {e}");
@@ -31,40 +23,49 @@ pub fn run() -> anyhow::Result<ExitCode> {
         }
     };
 
-    if report.actions.is_empty() && report.errors.is_empty() {
-        println!("Dotfiles: nothing to do (source directory is empty)");
-        return Ok(ExitCode::SUCCESS);
-    }
+    // Print dotfiles results
+    if let Some(ref dotfiles_report) = report.dotfiles {
+        if dotfiles_report.actions.is_empty() && dotfiles_report.errors.is_empty() {
+            println!("Dotfiles: nothing to do (source directory is empty)");
+        } else {
+            println!("Dotfiles:");
+            for action in &dotfiles_report.actions {
+                match action {
+                    DotfileAction::NewFile { target, .. } => {
+                        println!("  {} — new file", display_target(target));
+                    }
+                    DotfileAction::UpToDate { target } => {
+                        println!("  {} — up to date", display_target(target));
+                    }
+                    DotfileAction::CleanUpdate { target, .. } => {
+                        println!("  {} — clean update (repo changed)", display_target(target));
+                    }
+                    DotfileAction::LocalModification { target } => {
+                        println!(
+                            "  {} — local modification (not in repo)",
+                            display_target(target)
+                        );
+                    }
+                    DotfileAction::Conflict { target, .. } => {
+                        println!(
+                            "  {} — conflict (both sides changed, will back up)",
+                            display_target(target)
+                        );
+                    }
+                }
+            }
 
-    println!("Dotfiles:");
-    for action in &report.actions {
-        match action {
-            DotfileAction::NewFile { target, .. } => {
-                println!("  {} — new file", display_target(target));
-            }
-            DotfileAction::UpToDate { target } => {
-                println!("  {} — up to date", display_target(target));
-            }
-            DotfileAction::CleanUpdate { target, .. } => {
-                println!("  {} — clean update (repo changed)", display_target(target));
-            }
-            DotfileAction::LocalModification { target } => {
-                println!(
-                    "  {} — local modification (not in repo)",
-                    display_target(target)
-                );
-            }
-            DotfileAction::Conflict { target, .. } => {
-                println!(
-                    "  {} — conflict (both sides changed, will back up)",
-                    display_target(target)
-                );
+            for err in &dotfiles_report.errors {
+                eprintln!("  ⚠ {err}");
             }
         }
     }
 
-    for err in &report.errors {
-        eprintln!("  ⚠ {err}");
+    // Print pending phase warnings
+    for phase in &report.pending_phases {
+        if let Some(ref reason) = phase.skipped_reason {
+            println!("⚠ {reason}");
+        }
     }
 
     Ok(ExitCode::SUCCESS)
@@ -75,3 +76,4 @@ fn display_target(path: &std::path::Path) -> String {
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_else(|| path.display().to_string())
 }
+

--- a/src/cli/plan.rs
+++ b/src/cli/plan.rs
@@ -1,10 +1,11 @@
 use crate::config;
 use crate::reconcile::{self, dotfiles::DotfileAction};
 use crate::state::State;
+use std::path::Path;
 use std::process::ExitCode;
 
-pub fn run() -> anyhow::Result<ExitCode> {
-    let (_path, cfg) = match config::find_config() {
+pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
+    let (config_path, cfg) = match config::find_config_with_repo(repo) {
         Ok(result) => result,
         Err(e) => {
             eprintln!("{e}");
@@ -13,7 +14,10 @@ pub fn run() -> anyhow::Result<ExitCode> {
     };
 
     let state = State::load().unwrap_or_default();
-    let repo_root = std::env::current_dir()?;
+    let repo_root = config_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::env::current_dir().expect("cannot determine repo root"));
 
     let report = match reconcile::plan(&cfg, &state, &repo_root) {
         Ok(r) => r,

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,8 +1,9 @@
 use crate::config;
 use crate::platform;
+use std::path::Path;
 use std::process::ExitCode;
 
-pub fn run() -> anyhow::Result<ExitCode> {
+pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     // Platform detection
     match platform::detect() {
         Ok(platform) => {
@@ -15,7 +16,7 @@ pub fn run() -> anyhow::Result<ExitCode> {
     }
 
     // Config validity
-    match config::find_config() {
+    match config::find_config_with_repo(repo) {
         Ok((_path, config)) => {
             if let Some(df) = &config.dotfiles {
                 println!("Config:   nostos.toml (valid)");

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use crate::platform;
+use crate::state::State;
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -7,29 +8,46 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     // Platform detection
     match platform::detect() {
         Ok(platform) => {
-            println!("Platform: {platform}");
+            println!("Platform:  {platform}");
+            if !platform.managers.is_empty() {
+                let names: Vec<_> = platform.managers.iter().map(|m| m.name.as_str()).collect();
+                println!("Managers:  {}", names.join(", "));
+            }
         }
         Err(e) => {
-            eprintln!("Platform: {e}");
+            eprintln!("Platform:  {e}");
             return Ok(ExitCode::from(4));
         }
+    }
+
+    // State info (machine identity and repo path)
+    let state = State::load().unwrap_or_default();
+    if let Some(id) = state.machine_id() {
+        println!("Machine:   {id}");
+    }
+    if let Some(path) = state.repo_path() {
+        println!("Repo:      {path}");
     }
 
     // Config validity
     match config::find_config_with_repo(repo) {
         Ok((_path, config)) => {
+            println!("Config:    nostos.toml (valid)");
             if let Some(df) = &config.dotfiles {
-                println!("Config:   nostos.toml (valid)");
-                println!("Dotfiles: source={}, target={}", df.source, df.target);
-            } else {
-                println!("Config:   nostos.toml (no [dotfiles] section)");
+                println!("Dotfiles:  source={}, target={}", df.source, df.target);
+            }
+            if !config.tools.is_empty() {
+                println!("Tools:     {} declared (not yet active)", config.tools.len());
+            }
+            if !config.hooks.is_empty() {
+                println!("Hooks:     {} declared (not yet active)", config.hooks.len());
             }
         }
         Err(config::Error::NotFound { .. }) => {
-            println!("Config:   not found (no nostos.toml in current directory)");
+            println!("Config:    not found (no nostos.toml in current directory)");
         }
         Err(e) => {
-            eprintln!("Config:   invalid — {e}");
+            eprintln!("Config:    invalid — {e}");
             return Ok(ExitCode::from(3));
         }
     }

--- a/src/config/files.rs
+++ b/src/config/files.rs
@@ -1,0 +1,9 @@
+/// Configuration for the `[files]` section (verbatim copy, no dot-prepend).
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FilesConfig {
+    /// Source directory relative to repo root.
+    pub source: String,
+    /// Target directory.
+    pub target: String,
+}

--- a/src/config/hooks.rs
+++ b/src/config/hooks.rs
@@ -1,0 +1,25 @@
+/// Valid values for the hook `when` field.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HookWhen {
+    PreApply,
+    PostApply,
+}
+
+/// Configuration for a single `[[hook]]` entry.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HookConfig {
+    /// Unique name for this hook.
+    pub name: String,
+    /// Path to the script, relative to repo root.
+    pub run: String,
+    /// When this hook runs in the apply lifecycle.
+    pub when: HookWhen,
+    /// Platforms this hook applies to. Empty means all.
+    #[serde(default)]
+    pub platforms: Vec<String>,
+    /// Machines this hook applies to. Empty means all.
+    #[serde(default)]
+    pub machines: Vec<String>,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,8 +46,6 @@ pub struct Config {
 }
 
 /// Find and load `nostos.toml` in the current directory.
-///
-/// This is isolated behind a helper so adding `--repo` later is trivial.
 pub fn find_config() -> Result<(PathBuf, Config), Error> {
     let path = PathBuf::from("nostos.toml");
     if !path.exists() {
@@ -57,6 +55,34 @@ pub fn find_config() -> Result<(PathBuf, Config), Error> {
     }
     let config = load(&path)?;
     Ok((path, config))
+}
+
+/// Find config with resolution order: explicit path > state-stored path > current directory.
+pub fn find_config_with_repo(explicit_repo: Option<&Path>) -> Result<(PathBuf, Config), Error> {
+    // 1. Explicit --repo flag
+    if let Some(repo_path) = explicit_repo {
+        let config_path = repo_path.join("nostos.toml");
+        if !config_path.exists() {
+            return Err(Error::NotFound {
+                path: config_path.display().to_string(),
+            });
+        }
+        return load(&config_path).map(|c| (config_path, c));
+    }
+
+    // 2. State-stored repo path
+    if let Ok(state) = crate::state::State::load() {
+        if let Some(repo_path_str) = state.repo_path() {
+            let repo_path = PathBuf::from(repo_path_str);
+            let config_path = repo_path.join("nostos.toml");
+            if config_path.exists() {
+                return load(&config_path).map(|c| (config_path, c));
+            }
+        }
+    }
+
+    // 3. Current directory (existing behavior)
+    find_config()
 }
 
 /// Load and parse a nostos config from the given path.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,8 @@
 pub mod dotfiles;
+pub mod files;
+pub mod hooks;
+pub mod preferences;
+pub mod tools;
 
 use std::path::{Path, PathBuf};
 
@@ -32,6 +36,13 @@ pub enum Error {
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub dotfiles: Option<dotfiles::DotfilesConfig>,
+    #[serde(default, rename = "tool")]
+    pub tools: Vec<tools::ToolConfig>,
+    #[serde(default, rename = "hook")]
+    pub hooks: Vec<hooks::HookConfig>,
+    pub files: Option<files::FilesConfig>,
+    #[serde(default)]
+    pub preferences: Option<preferences::PreferencesConfig>,
 }
 
 /// Find and load `nostos.toml` in the current directory.
@@ -194,5 +205,188 @@ mod tests {
         let df = config.dotfiles.expect("dotfiles present");
         assert_eq!(df.source, "");
         assert_eq!(df.target, "");
+    }
+
+    #[test]
+    fn config_with_tools() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [[tool]]
+            name = "ripgrep"
+            bin = "rg"
+
+            [[tool]]
+            name = "fd"
+            install.apt = "fd-find"
+            install.cargo = "fd-find"
+            platforms = ["linux"]
+            "#,
+        )
+        .expect("should parse");
+        assert_eq!(config.tools.len(), 2);
+        assert_eq!(config.tools[0].name, "ripgrep");
+        assert_eq!(config.tools[0].bin.as_deref(), Some("rg"));
+        assert_eq!(config.tools[1].install.get("apt").unwrap(), "fd-find");
+        assert_eq!(config.tools[1].platforms, vec!["linux"]);
+    }
+
+    #[test]
+    fn config_with_hooks() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [[hook]]
+            name = "install-homebrew"
+            run = "hooks/install-homebrew.sh"
+            when = "pre-apply"
+            platforms = ["macos"]
+            "#,
+        )
+        .expect("should parse");
+        assert_eq!(config.hooks.len(), 1);
+        assert_eq!(config.hooks[0].name, "install-homebrew");
+        assert_eq!(config.hooks[0].when, hooks::HookWhen::PreApply);
+    }
+
+    #[test]
+    fn config_with_files_section() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [files]
+            source = "files/"
+            target = "~"
+            "#,
+        )
+        .expect("should parse");
+        let files = config.files.expect("files should be present");
+        assert_eq!(files.source, "files/");
+    }
+
+    #[test]
+    fn config_with_preferences() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [preferences.macos]
+            installer-priority = ["brew", "cargo"]
+
+            [preferences.linux.ubuntu]
+            installer-priority = ["apt", "cargo"]
+            "#,
+        )
+        .expect("should parse");
+        let prefs = config.preferences.expect("preferences present");
+        let macos = prefs.macos.expect("macos prefs");
+        assert_eq!(macos.installer_priority, vec!["brew", "cargo"]);
+    }
+
+    #[test]
+    fn tool_missing_name() {
+        let result = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [[tool]]
+            bin = "rg"
+            "#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hook_invalid_when() {
+        let result = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [[hook]]
+            name = "test"
+            run = "hooks/test.sh"
+            when = "during-apply"
+            "#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hook_missing_required_fields() {
+        let result = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [[hook]]
+            name = "test"
+            "#,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn full_realistic_config() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [preferences.macos]
+            installer-priority = ["brew", "cargo"]
+
+            [preferences.windows]
+            installer-priority = ["winget", "scoop", "cargo"]
+
+            [preferences.linux.ubuntu]
+            installer-priority = ["apt", "cargo"]
+
+            [[tool]]
+            name = "ripgrep"
+            bin = "rg"
+
+            [[tool]]
+            name = "fd"
+            install.apt = "fd-find"
+            install.cargo = "fd-find"
+
+            [[tool]]
+            name = "cargo-edit"
+            bin = "cargo-add"
+            install.cargo = "cargo-edit"
+
+            [[hook]]
+            name = "install-homebrew"
+            run = "hooks/install-homebrew.sh"
+            when = "pre-apply"
+            platforms = ["macos"]
+
+            [[hook]]
+            name = "setup-ssh"
+            run = "hooks/setup-ssh.sh"
+            when = "post-apply"
+            platforms = ["linux", "macos"]
+            "#,
+        )
+        .expect("should parse full config");
+        assert_eq!(config.tools.len(), 3);
+        assert_eq!(config.hooks.len(), 2);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,13 +71,13 @@ pub fn find_config_with_repo(explicit_repo: Option<&Path>) -> Result<(PathBuf, C
     }
 
     // 2. State-stored repo path
-    if let Ok(state) = crate::state::State::load() {
-        if let Some(repo_path_str) = state.repo_path() {
-            let repo_path = PathBuf::from(repo_path_str);
-            let config_path = repo_path.join("nostos.toml");
-            if config_path.exists() {
-                return load(&config_path).map(|c| (config_path, c));
-            }
+    if let Ok(state) = crate::state::State::load()
+        && let Some(repo_path_str) = state.repo_path()
+    {
+        let repo_path = PathBuf::from(repo_path_str);
+        let config_path = repo_path.join("nostos.toml");
+        if config_path.exists() {
+            return load(&config_path).map(|c| (config_path, c));
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,6 +85,18 @@ pub fn find_config_with_repo(explicit_repo: Option<&Path>) -> Result<(PathBuf, C
     find_config()
 }
 
+/// Derive the repo root directory from a config file path.
+///
+/// Falls back to the current working directory when the config path is a
+/// bare filename (e.g. `"nostos.toml"`) whose `.parent()` is empty.
+pub fn repo_root_from_config(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::env::current_dir().expect("cannot determine repo root"))
+}
+
 /// Load and parse a nostos config from the given path.
 pub fn load(path: &Path) -> Result<Config, Error> {
     let content = std::fs::read_to_string(path).map_err(|e| Error::ReadError {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -427,4 +427,26 @@ mod tests {
         assert_eq!(config.tools.len(), 3);
         assert_eq!(config.hooks.len(), 2);
     }
+
+    #[test]
+    fn repo_root_from_bare_filename_uses_cwd() {
+        let path = Path::new("nostos.toml");
+        let root = repo_root_from_config(path);
+        assert!(!root.as_os_str().is_empty(), "should not be empty");
+        assert!(root.is_absolute(), "should fall back to absolute cwd");
+    }
+
+    #[test]
+    fn repo_root_from_absolute_path() {
+        let path = Path::new("/home/user/dotfiles/nostos.toml");
+        let root = repo_root_from_config(path);
+        assert_eq!(root, Path::new("/home/user/dotfiles"));
+    }
+
+    #[test]
+    fn repo_root_from_relative_path_with_dir() {
+        let path = Path::new("my-repo/nostos.toml");
+        let root = repo_root_from_config(path);
+        assert_eq!(root, Path::new("my-repo"));
+    }
 }

--- a/src/config/preferences.rs
+++ b/src/config/preferences.rs
@@ -1,0 +1,29 @@
+/// Per-platform installer preferences.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct PreferencesConfig {
+    /// macOS preferences.
+    pub macos: Option<PlatformPreferences>,
+    /// Windows preferences.
+    pub windows: Option<PlatformPreferences>,
+    /// Linux preferences — either generic or per-distro.
+    pub linux: Option<LinuxPreferences>,
+}
+
+/// Preferences for a single platform.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatformPreferences {
+    #[serde(rename = "installer-priority")]
+    pub installer_priority: Vec<String>,
+}
+
+/// Linux preferences with optional per-distro overrides.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LinuxPreferences {
+    /// Fallback priority for unrecognized distros.
+    #[serde(rename = "installer-priority", default)]
+    pub installer_priority: Vec<String>,
+    /// Per-distro overrides. Flatten captures distro-named sub-tables.
+    #[serde(flatten)]
+    pub distros: std::collections::BTreeMap<String, PlatformPreferences>,
+}

--- a/src/config/tools.rs
+++ b/src/config/tools.rs
@@ -1,0 +1,16 @@
+/// Configuration for a single `[[tool]]` entry.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolConfig {
+    /// Tool name (also the default package name for all managers).
+    pub name: String,
+    /// Binary name to check for presence on PATH. Defaults to `name`.
+    pub bin: Option<String>,
+    /// Per-manager install overrides. Keys are manager names, values are package names.
+    /// Special key: "script" for script-based installation.
+    #[serde(default)]
+    pub install: std::collections::BTreeMap<String, String>,
+    /// Platforms this tool applies to. Empty/absent means all platforms.
+    #[serde(default)]
+    pub platforms: Vec<String>,
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,6 +1,8 @@
 mod os;
+pub mod packages;
 
 pub use os::{Arch, Distro, Os};
+pub use packages::PackageManager;
 
 /// Detected platform information.
 #[derive(Debug, Clone)]
@@ -8,6 +10,7 @@ pub struct Platform {
     pub os: Os,
     pub arch: Arch,
     pub distro: Option<Distro>,
+    pub managers: Vec<PackageManager>,
 }
 
 /// Errors that can occur during platform detection.
@@ -28,7 +31,9 @@ pub fn detect() -> Result<Platform, Error> {
         None
     };
 
-    Ok(Platform { os, arch, distro })
+    let managers = packages::discover();
+
+    Ok(Platform { os, arch, distro, managers })
 }
 
 impl std::fmt::Display for Platform {

--- a/src/platform/packages.rs
+++ b/src/platform/packages.rs
@@ -1,0 +1,113 @@
+use std::path::PathBuf;
+
+/// A package manager detected on the current system.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PackageManager {
+    /// Short name (e.g., "brew", "apt", "cargo", "winget").
+    pub name: String,
+    /// Path to the binary.
+    pub path: PathBuf,
+}
+
+impl std::fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+/// Known package managers to check for.
+const KNOWN_MANAGERS: &[&str] = &[
+    "apt",
+    "brew",
+    "cargo",
+    "choco",
+    "dnf",
+    "pacman",
+    "pip",
+    "scoop",
+    "snap",
+    "winget",
+    "yum",
+];
+
+/// Discover which package managers are available on the current system.
+/// Checks PATH for known manager binaries.
+pub fn discover() -> Vec<PackageManager> {
+    let mut found = Vec::new();
+    for &name in KNOWN_MANAGERS {
+        if let Some(path) = which(name) {
+            found.push(PackageManager {
+                name: name.to_string(),
+                path,
+            });
+        }
+    }
+    found.sort();
+    found
+}
+
+/// Simple `which`-like lookup: find a binary on PATH.
+fn which(binary: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    let sep = if cfg!(windows) { ';' } else { ':' };
+    for dir in path_var.to_string_lossy().split(sep) {
+        let candidate = PathBuf::from(dir).join(binary);
+        // On Windows, also check with .exe extension
+        if cfg!(windows) {
+            let with_exe = candidate.with_extension("exe");
+            if with_exe.is_file() {
+                return Some(with_exe);
+            }
+        }
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_finds_at_least_one_manager() {
+        // On any development machine, at least cargo should be available
+        // (since we're building a Rust project)
+        let managers = discover();
+        assert!(
+            !managers.is_empty(),
+            "expected at least one package manager (cargo) to be detected"
+        );
+    }
+
+    #[test]
+    fn discover_finds_cargo() {
+        // Since we're running in a Rust build environment, cargo must be present
+        let managers = discover();
+        assert!(
+            managers.iter().any(|m| m.name == "cargo"),
+            "cargo should be detected in a Rust build environment"
+        );
+    }
+
+    #[test]
+    fn which_finds_existing_binary() {
+        // cargo must exist since we're running cargo test
+        assert!(which("cargo").is_some());
+    }
+
+    #[test]
+    fn which_returns_none_for_nonexistent() {
+        assert!(which("nonexistent_binary_xyz_12345").is_none());
+    }
+
+    #[test]
+    fn package_manager_display() {
+        let pm = PackageManager {
+            name: "brew".to_string(),
+            path: PathBuf::from("/usr/local/bin/brew"),
+        };
+        assert_eq!(format!("{pm}"), "brew");
+    }
+}

--- a/src/reconcile/mod.rs
+++ b/src/reconcile/mod.rs
@@ -1,1 +1,277 @@
 pub mod dotfiles;
+
+use crate::config::Config;
+use crate::state::State;
+use std::path::Path;
+
+/// Summary of a single reconciliation phase.
+#[derive(Debug, Default)]
+pub struct PhaseReport {
+    /// Human-readable name of the phase.
+    pub phase: String,
+    /// Whether this phase actually executed.
+    pub executed: bool,
+    /// Warning message if the phase was skipped (not yet implemented).
+    pub skipped_reason: Option<String>,
+}
+
+/// Top-level report aggregating all reconciliation phases.
+#[derive(Debug, Default)]
+pub struct ApplyReport {
+    /// Results from the dotfiles phase.
+    pub dotfiles: Option<dotfiles::Report>,
+    /// Phase summaries for phases that are not yet implemented.
+    pub pending_phases: Vec<PhaseReport>,
+}
+
+impl ApplyReport {
+    /// Whether any phase produced warnings requiring user attention.
+    pub fn has_warnings(&self) -> bool {
+        self.dotfiles.as_ref().is_some_and(|r| r.has_warnings())
+    }
+
+    /// Whether any phase had errors.
+    pub fn has_errors(&self) -> bool {
+        self.dotfiles.as_ref().is_some_and(|r| !r.errors.is_empty())
+    }
+}
+
+/// Build a plan (dry-run) across all phases.
+pub fn plan(config: &Config, state: &State, repo_root: &Path) -> Result<ApplyReport, PlanError> {
+    let mut report = ApplyReport::default();
+
+    // Phase 1: Pre-apply hooks (not yet implemented)
+    if !config.hooks.is_empty() {
+        let pre_hooks: Vec<_> = config
+            .hooks
+            .iter()
+            .filter(|h| h.when == crate::config::hooks::HookWhen::PreApply)
+            .collect();
+        if !pre_hooks.is_empty() {
+            report.pending_phases.push(PhaseReport {
+                phase: "pre-apply hooks".to_string(),
+                executed: false,
+                skipped_reason: Some(format!(
+                    "{} pre-apply hook(s) declared but hook execution is not yet implemented",
+                    pre_hooks.len()
+                )),
+            });
+        }
+    }
+
+    // Phase 2: Dotfiles (active)
+    if let Some(ref dotfiles_config) = config.dotfiles {
+        let dotfiles_report =
+            dotfiles::plan(dotfiles_config, state, repo_root).map_err(PlanError::Dotfiles)?;
+        report.dotfiles = Some(dotfiles_report);
+    }
+
+    // Phase 3: Tools (not yet implemented)
+    if !config.tools.is_empty() {
+        report.pending_phases.push(PhaseReport {
+            phase: "tools".to_string(),
+            executed: false,
+            skipped_reason: Some(format!(
+                "{} tool(s) declared but tool installation is not yet implemented",
+                config.tools.len()
+            )),
+        });
+    }
+
+    // Phase 4: Post-apply hooks (not yet implemented)
+    if !config.hooks.is_empty() {
+        let post_hooks: Vec<_> = config
+            .hooks
+            .iter()
+            .filter(|h| h.when == crate::config::hooks::HookWhen::PostApply)
+            .collect();
+        if !post_hooks.is_empty() {
+            report.pending_phases.push(PhaseReport {
+                phase: "post-apply hooks".to_string(),
+                executed: false,
+                skipped_reason: Some(format!(
+                    "{} post-apply hook(s) declared but hook execution is not yet implemented",
+                    post_hooks.len()
+                )),
+            });
+        }
+    }
+
+    // Files section (not yet implemented)
+    if config.files.is_some() {
+        report.pending_phases.push(PhaseReport {
+            phase: "files".to_string(),
+            executed: false,
+            skipped_reason: Some(
+                "[files] section declared but verbatim file copy is not yet implemented"
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok(report)
+}
+
+/// Apply all phases: execute changes.
+pub fn apply(
+    config: &Config,
+    state: &mut State,
+    repo_root: &Path,
+) -> Result<ApplyReport, ApplyError> {
+    let mut report = ApplyReport::default();
+
+    // Phase 1: Pre-apply hooks (not yet implemented)
+    if !config.hooks.is_empty() {
+        let pre_hooks: Vec<_> = config
+            .hooks
+            .iter()
+            .filter(|h| h.when == crate::config::hooks::HookWhen::PreApply)
+            .collect();
+        if !pre_hooks.is_empty() {
+            report.pending_phases.push(PhaseReport {
+                phase: "pre-apply hooks".to_string(),
+                executed: false,
+                skipped_reason: Some(format!(
+                    "{} pre-apply hook(s) declared but hook execution is not yet implemented",
+                    pre_hooks.len()
+                )),
+            });
+        }
+    }
+
+    // Phase 2: Dotfiles (active)
+    if let Some(ref dotfiles_config) = config.dotfiles {
+        let dotfiles_report = dotfiles::apply(dotfiles_config, state, repo_root)
+            .map_err(ApplyError::Dotfiles)?;
+        report.dotfiles = Some(dotfiles_report);
+    }
+
+    // Phase 3: Tools (not yet implemented)
+    if !config.tools.is_empty() {
+        report.pending_phases.push(PhaseReport {
+            phase: "tools".to_string(),
+            executed: false,
+            skipped_reason: Some(format!(
+                "{} tool(s) declared but tool installation is not yet implemented",
+                config.tools.len()
+            )),
+        });
+    }
+
+    // Phase 4: Post-apply hooks (not yet implemented)
+    if !config.hooks.is_empty() {
+        let post_hooks: Vec<_> = config
+            .hooks
+            .iter()
+            .filter(|h| h.when == crate::config::hooks::HookWhen::PostApply)
+            .collect();
+        if !post_hooks.is_empty() {
+            report.pending_phases.push(PhaseReport {
+                phase: "post-apply hooks".to_string(),
+                executed: false,
+                skipped_reason: Some(format!(
+                    "{} post-apply hook(s) declared but hook execution is not yet implemented",
+                    post_hooks.len()
+                )),
+            });
+        }
+    }
+
+    // Files section (not yet implemented)
+    if config.files.is_some() {
+        report.pending_phases.push(PhaseReport {
+            phase: "files".to_string(),
+            executed: false,
+            skipped_reason: Some(
+                "[files] section declared but verbatim file copy is not yet implemented"
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok(report)
+}
+
+/// Errors from plan operation.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PlanError {
+    #[error("dotfiles: {0}")]
+    Dotfiles(#[from] dotfiles::Error),
+}
+
+/// Errors from apply operation.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ApplyError {
+    #[error("dotfiles: {0}")]
+    Dotfiles(#[from] dotfiles::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::state::State;
+    use std::path::Path;
+
+    fn empty_config() -> Config {
+        toml::from_str("").unwrap()
+    }
+
+    #[test]
+    fn plan_empty_config_succeeds() {
+        let config = empty_config();
+        let state = State::default();
+        let report = plan(&config, &state, Path::new("/nonexistent")).unwrap();
+        assert!(report.dotfiles.is_none());
+        assert!(report.pending_phases.is_empty());
+    }
+
+    #[test]
+    fn plan_full_config_reports_pending_phases() {
+        let config: Config = toml::from_str(
+            r#"
+            [[tool]]
+            name = "ripgrep"
+
+            [[hook]]
+            name = "setup"
+            run = "hooks/setup.sh"
+            when = "pre-apply"
+
+            [[hook]]
+            name = "cleanup"
+            run = "hooks/cleanup.sh"
+            when = "post-apply"
+
+            [files]
+            source = "files/"
+            target = "~"
+        "#,
+        )
+        .unwrap();
+        let state = State::default();
+        let report = plan(&config, &state, Path::new("/nonexistent")).unwrap();
+        assert!(report.dotfiles.is_none());
+        // Should have: pre-apply hooks, tools, post-apply hooks, files = 4 pending phases
+        assert_eq!(report.pending_phases.len(), 4);
+        assert!(report.pending_phases.iter().any(|p| p.phase == "tools"));
+        assert!(report
+            .pending_phases
+            .iter()
+            .any(|p| p.phase == "pre-apply hooks"));
+        assert!(report
+            .pending_phases
+            .iter()
+            .any(|p| p.phase == "post-apply hooks"));
+        assert!(report.pending_phases.iter().any(|p| p.phase == "files"));
+    }
+
+    #[test]
+    fn apply_report_has_warnings_delegation() {
+        let report = ApplyReport::default();
+        assert!(!report.has_warnings());
+        assert!(!report.has_errors());
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -140,8 +140,20 @@ fn parent_or_dot(path: &Path) -> &Path {
 }
 
 /// Get the default state file path for this platform.
+///
+/// Checks `XDG_CONFIG_HOME` first (standard on Linux, also useful for test
+/// isolation on macOS where `dirs::config_dir()` ignores it), then falls
+/// back to the platform config directory.
 fn default_state_path() -> Result<PathBuf, Error> {
-    let config_dir = dirs::config_dir().ok_or(Error::NoConfigDir)?;
+    let config_dir = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| dirs::config_dir().unwrap_or_default());
+
+    if config_dir.as_os_str().is_empty() {
+        return Err(Error::NoConfigDir);
+    }
+
     Ok(config_dir.join("nostos").join("state.toml"))
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,13 +1,35 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// Machine identity information.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct MachineInfo {
+    /// Machine identifier (hostname by default, or user-assigned).
+    pub id: String,
+}
+
+/// Repository location information.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RepoInfo {
+    /// Absolute path to the repository root on this machine.
+    pub path: String,
+}
+
 /// Local state tracking what nostos has applied on this machine.
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct State {
+    /// Machine identity.
+    #[serde(default)]
+    pub machine: Option<MachineInfo>,
+
     /// Per-file tracking of applied hashes and timestamps.
     /// Keys are target-relative paths with dot prepended (e.g., ".bashrc").
     #[serde(default)]
     pub applied: BTreeMap<String, AppliedEntry>,
+
+    /// Location of the dotfiles repository on this machine.
+    #[serde(default)]
+    pub repo: Option<RepoInfo>,
 }
 
 /// Record of a single applied dotfile.
@@ -37,6 +59,29 @@ pub enum Error {
 }
 
 impl State {
+    /// Ensure machine identity is set. If not already present, detect from hostname.
+    pub fn ensure_machine_identity(&mut self) {
+        if self.machine.is_none() {
+            let id = detect_hostname().unwrap_or_else(|| "unknown".to_string());
+            self.machine = Some(MachineInfo { id });
+        }
+    }
+
+    /// Get the machine ID, if set.
+    pub fn machine_id(&self) -> Option<&str> {
+        self.machine.as_ref().map(|m| m.id.as_str())
+    }
+
+    /// Get the stored repo path, if any.
+    pub fn repo_path(&self) -> Option<&str> {
+        self.repo.as_ref().map(|r| r.path.as_str())
+    }
+
+    /// Set the repo path. Used on first apply to remember where the repo is.
+    pub fn set_repo_path(&mut self, path: String) {
+        self.repo = Some(RepoInfo { path });
+    }
+
     /// Load state from the platform-appropriate location.
     pub fn load() -> Result<Self, Error> {
         let path = default_state_path()?;
@@ -98,6 +143,37 @@ fn parent_or_dot(path: &Path) -> &Path {
 fn default_state_path() -> Result<PathBuf, Error> {
     let config_dir = dirs::config_dir().ok_or(Error::NoConfigDir)?;
     Ok(config_dir.join("nostos").join("state.toml"))
+}
+
+/// Detect the system hostname.
+fn detect_hostname() -> Option<String> {
+    // Try HOSTNAME env var first (common on Linux)
+    if let Ok(h) = std::env::var("HOSTNAME")
+        && !h.is_empty()
+    {
+        return Some(h);
+    }
+
+    // Try COMPUTERNAME on Windows
+    if let Ok(h) = std::env::var("COMPUTERNAME")
+        && !h.is_empty()
+    {
+        return Some(h);
+    }
+
+    hostname_from_command()
+}
+
+fn hostname_from_command() -> Option<String> {
+    use std::process::Command;
+    let output = Command::new("hostname").output().ok()?;
+    if output.status.success() {
+        let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -316,5 +392,97 @@ mod tests {
             .collect();
         assert_eq!(entries.len(), 1, "leaked entries: {entries:?}");
         assert_eq!(entries[0], "state.toml");
+    }
+
+    #[test]
+    fn state_with_machine_identity_roundtrips() {
+        let state = State {
+            machine: Some(MachineInfo {
+                id: "work-macbook".to_string(),
+            }),
+            applied: BTreeMap::new(),
+            repo: None,
+        };
+        let serialized = toml::to_string_pretty(&state).unwrap();
+        let deserialized: State = toml::from_str(&serialized).unwrap();
+        assert_eq!(state, deserialized);
+    }
+
+    #[test]
+    fn state_without_machine_loads_as_none() {
+        let state: State = toml::from_str("[applied]\n").unwrap();
+        assert!(state.machine.is_none());
+    }
+
+    #[test]
+    fn ensure_machine_identity_sets_id() {
+        let mut state = State::default();
+        assert!(state.machine.is_none());
+        state.ensure_machine_identity();
+        assert!(state.machine.is_some());
+        assert!(!state.machine.as_ref().unwrap().id.is_empty());
+    }
+
+    #[test]
+    fn ensure_machine_identity_preserves_existing() {
+        let mut state = State {
+            machine: Some(MachineInfo {
+                id: "my-machine".to_string(),
+            }),
+            applied: BTreeMap::new(),
+            repo: None,
+        };
+        state.ensure_machine_identity();
+        assert_eq!(state.machine_id(), Some("my-machine"));
+    }
+
+    #[test]
+    fn legacy_state_without_machine_section() {
+        // Old state files from before machine identity was added should still load
+        let toml_str = r#"
+[applied]
+".bashrc" = { hash = "sha256:abc123", timestamp = "2026-04-26T20:00:00Z" }
+"#;
+        let state: State = toml::from_str(toml_str).unwrap();
+        assert!(state.machine.is_none());
+        assert_eq!(state.applied.len(), 1);
+    }
+
+    #[test]
+    fn state_with_repo_path_roundtrips() {
+        let state = State {
+            repo: Some(RepoInfo {
+                path: "/home/user/dotfiles".to_string(),
+            }),
+            ..Default::default()
+        };
+        let serialized = toml::to_string_pretty(&state).unwrap();
+        let deserialized: State = toml::from_str(&serialized).unwrap();
+        assert_eq!(state.repo, deserialized.repo);
+    }
+
+    #[test]
+    fn state_without_repo_loads_as_none() {
+        let state: State = toml::from_str("[applied]\n").unwrap();
+        assert!(state.repo.is_none());
+    }
+
+    #[test]
+    fn set_repo_path_stores_path() {
+        let mut state = State::default();
+        assert!(state.repo_path().is_none());
+        state.set_repo_path("/home/user/dotfiles".to_string());
+        assert_eq!(state.repo_path(), Some("/home/user/dotfiles"));
+    }
+
+    #[test]
+    fn legacy_state_without_repo_section() {
+        let toml_str = r#"
+[applied]
+".bashrc" = { hash = "sha256:abc123", timestamp = "2026-04-26T20:00:00Z" }
+"#;
+        let state: State = toml::from_str(toml_str).unwrap();
+        assert!(state.repo.is_none());
+        assert_eq!(state.applied.len(), 1);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -234,3 +234,78 @@ fn no_subcommand_shows_help() {
         .code(2)
         .stderr(predicate::str::contains("Usage"));
 }
+
+// ── --repo flag tests ────────────────────────────────────
+
+#[test]
+fn apply_with_repo_flag() {
+    let fixture = TestFixture::new().with_default_config();
+    fixture.add_source("bashrc", "# bash config");
+
+    // Run from a different directory using --repo
+    let other_dir = TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("--repo")
+        .arg(fixture.dir.path())
+        .arg("apply")
+        .current_dir(other_dir.path())
+        .assert()
+        .success();
+
+    // Verify file was placed
+    assert!(fixture.target_dir().join(".bashrc").exists());
+}
+
+#[test]
+fn plan_with_repo_flag() {
+    let fixture = TestFixture::new().with_default_config();
+    fixture.add_source("bashrc", "# bash config");
+
+    let other_dir = TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("--repo")
+        .arg(fixture.dir.path())
+        .arg("plan")
+        .current_dir(other_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("new file"));
+}
+
+#[test]
+fn status_with_repo_flag() {
+    let fixture = TestFixture::new().with_default_config();
+
+    let other_dir = TempDir::new().unwrap();
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("--repo")
+        .arg(fixture.dir.path())
+        .arg("status")
+        .current_dir(other_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("valid"));
+}
+
+#[test]
+fn repo_flag_nonexistent_path() {
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .arg("--repo")
+        .arg("/nonexistent/path/xyz")
+        .arg("plan")
+        .assert()
+        .failure();
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -309,3 +309,105 @@ fn repo_flag_nonexistent_path() {
         .assert()
         .failure();
 }
+
+#[test]
+fn plan_with_tools_shows_not_yet_implemented() {
+    let fixture = TestFixture::new();
+    let target = fixture.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        r#"[dotfiles]
+source = "dotfiles/"
+target = "{target}"
+
+[[tool]]
+name = "ripgrep"
+bin = "rg"
+
+[[tool]]
+name = "fd"
+install.apt = "fd-find"
+"#
+    );
+    fs::write(fixture.dir.path().join("nostos.toml"), config).unwrap();
+    fixture.add_source("bashrc", "# config");
+
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("plan")
+        .current_dir(fixture.dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2 tool(s) declared but tool installation is not yet implemented"));
+}
+
+#[test]
+fn plan_with_hooks_shows_not_yet_implemented() {
+    let fixture = TestFixture::new();
+    let target = fixture.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        r#"[dotfiles]
+source = "dotfiles/"
+target = "{target}"
+
+[[hook]]
+name = "setup"
+run = "hooks/setup.sh"
+when = "pre-apply"
+"#
+    );
+    fs::write(fixture.dir.path().join("nostos.toml"), config).unwrap();
+    fixture.add_source("bashrc", "# config");
+
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("plan")
+        .current_dir(fixture.dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hook execution is not yet implemented"));
+}
+
+#[test]
+fn status_shows_platform_and_managers() {
+    let fixture = TestFixture::new().with_default_config();
+
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("status")
+        .current_dir(fixture.dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Platform:"))
+        .stdout(predicate::str::contains("Managers:"));
+}
+
+#[test]
+fn config_only_tools_no_dotfiles_is_valid() {
+    let fixture = TestFixture::new();
+    let config = r#"
+[[tool]]
+name = "ripgrep"
+bin = "rg"
+"#;
+    fs::write(fixture.dir.path().join("nostos.toml"), config).unwrap();
+
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        fixture.dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("plan")
+        .current_dir(fixture.dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tool(s) declared"));
+}


### PR DESCRIPTION
## Summary

Ship the minimum viable release: reliable dotfile management with forward-compatible config schema and architectural foundations for future features (tool installation, hooks, git operations).

## What's included

### Core features
- **Full config schema** — `[[tool]]`, `[[hook]]`, `[files]`, `[preferences]` sections parse and validate now, even though only `[dotfiles]` is executed today
- **Package manager discovery** — PATH-based detection of available managers (apt, brew, cargo, etc.)
- **Machine identity** — auto-detected from hostname, stored in state for future per-machine config
- **Repo path tracking** — remembers where your config lives after first `apply`
- **`--repo` flag** — override config location from anywhere; resolution chain: flag > state > cwd
- **Phased reconciler** — orchestration layer runs pre-hooks > dotfiles > tools > post-hooks > files, skipping unimplemented phases with clear warnings
- **Enhanced `status` command** — shows platform, available managers, machine identity, repo path, and config summary

### Infrastructure
- **GitHub Actions CI** — clippy + test matrix on Linux/macOS/Windows
- **109 tests** (84 unit + 19 CLI integration + 6 workflow E2E)

### Bug fix
- **`repo_root_from_config` helper** — fixes edge case where bare `"nostos.toml"` produced an empty repo root (`.parent()` returns `Some("")` not `None`)

## Design decisions

- `deny_unknown_fields` on top-level Config ensures typos are caught, while known-but-unimplemented sections validate cleanly
- Unimplemented phases produce warnings (not errors) so configs can be written today and "just work" when features ship
- State uses `serde(default)` on all new fields for backward compatibility
- Hook timing is `PreApply`/`PostApply` only — the phased reconciler makes mid-phase hooks trivial to add later

## Testing

All 109 tests pass. Clippy clean. Coverage includes:
- Config parsing for all schema types (tools, hooks, files, preferences)
- Forward-compat warnings when tools/hooks are declared but unimplemented
- `--repo` flag resolution chain
- `repo_root_from_config` edge cases (bare filename, absolute path, relative path)
- Full dotfile workflow E2E (fresh setup, edit+reapply, conflicts, nested dirs)

## Note

Commits are not GPG-signed (cherry-pick consolidation). Will squash-and-sign before merge.
