### PR TITLE
test: verify dotfile apply preserves pre-existing directory contents

### DIFF
--- a/src/reconcile/dotfiles.rs
+++ b/src/reconcile/dotfiles.rs
@@ -841,6 +841,32 @@ mod tests {
     }
 
     #[test]
+    fn apply_preserves_existing_directory_contents() {
+        let repo = TestRepo::new();
+
+        // Pre-populate the target with existing content in .config/
+        repo.add_target(".config/existing-app/settings.json", r#"{"theme":"dark"}"#);
+        repo.add_target(".config/other.conf", "existing config");
+
+        // Source repo wants to place config/foo/bar.toml → .config/foo/bar.toml
+        repo.add_source("config/foo/bar.toml", "new dotfile content");
+        let mut state = State::default();
+        let config = repo.config();
+
+        apply(&config, &mut state, &repo.repo_root).unwrap();
+
+        // New file was placed correctly
+        assert_eq!(repo.read_target(".config/foo/bar.toml"), "new dotfile content");
+
+        // Pre-existing content is untouched
+        assert_eq!(
+            repo.read_target(".config/existing-app/settings.json"),
+            r#"{"theme":"dark"}"#,
+        );
+        assert_eq!(repo.read_target(".config/other.conf"), "existing config");
+    }
+
+    #[test]
     fn dot_prepend_convention() {
         assert_eq!(dot_prepend("bashrc"), ".bashrc");
         assert_eq!(dot_prepend("config/starship.toml"), ".config/starship.toml");

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -265,7 +265,35 @@ fn workflow_mixed_state_batch() {
     );
 }
 
-// ── Workflow 6: Nested directory creation ────────────────
+// ── Workflow 6: Pre-existing directory with content ──────
+
+#[test]
+fn workflow_preexisting_directory_preserved() {
+    let w = Workflow::new();
+    w.write_config();
+
+    // Simulate a host where ~/.config already exists with user content
+    w.edit_target(".config/existing-app/settings.json", r#"{"theme":"dark"}"#);
+    w.edit_target(".config/other.conf", "keep me");
+
+    // Dotfiles repo adds config/foo → .config/foo
+    w.add_source("config/foo/bar.toml", "new dotfile");
+
+    // Apply should succeed
+    w.nostos().arg("apply").assert().success();
+
+    // New dotfile was placed
+    assert_eq!(w.read_target(".config/foo/bar.toml"), "new dotfile");
+
+    // Pre-existing content is untouched
+    assert_eq!(
+        w.read_target(".config/existing-app/settings.json"),
+        r#"{"theme":"dark"}"#,
+    );
+    assert_eq!(w.read_target(".config/other.conf"), "keep me");
+}
+
+// ── Workflow 7: Nested directory creation ────────────────
 
 #[test]
 fn workflow_nested_directory_creation() {


### PR DESCRIPTION
## Summary

When a target directory (e.g. `~/.config`) already exists on the host with user content, applying dotfiles into it should place new files correctly without disturbing existing content.

The implementation handles this correctly via `std::fs::create_dir_all` in `copy_file()` (idempotent on existing directories), but no test explicitly verified this invariant.

## Changes

Two new tests covering this scenario:

- **`apply_preserves_existing_directory_contents`** (unit, `src/reconcile/dotfiles.rs`) — pre-populates `.config/` with existing files, applies a new dotfile into `.config/foo/`, asserts both the new file lands and pre-existing files are untouched.
- **`workflow_preexisting_directory_preserved`** (E2E, `tests/workflows.rs`) — same scenario exercised end-to-end through the `nostos apply` CLI.