### PR TITLE
feat: add git CLI wrapper module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ path = "tests/cli.rs"
 name = "workflows"
 path = "tests/workflows.rs"
 
+[[test]]
+name = "git"
+path = "tests/git.rs"
+
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -218,7 +218,7 @@ fn classify_error(operation: &str, path: &str, stderr: &str) -> Error {
     }
 
     if lower.contains("authentication")
-        || lower.contains("permission denied")
+        || lower.contains("permission denied (publickey")
         || lower.contains("could not read from remote")
     {
         return Error::AuthFailed {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,225 @@
+//! Git CLI wrapper — shells out to the `git` binary for all git operations.
+//!
+//! See ADR 0001 for the rationale: using the CLI inherits the user's existing
+//! authentication config (SSH agent, credential managers) transparently.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Outcome of a [`commit`] call when the operation succeeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitOutcome {
+    /// Changes were staged and committed.
+    Committed,
+    /// The working tree was already clean — nothing to commit.
+    NothingToCommit,
+}
+
+/// Errors arising from git operations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The target path is not inside a git repository.
+    #[error("not a git repository: {path}")]
+    NotARepo {
+        /// The path that was expected to be a git repo.
+        path: String,
+    },
+
+    /// A merge or rebase conflict occurred during pull.
+    #[error("merge conflict in {path} — resolve conflicts with git tools, then re-run nostos")]
+    MergeConflict {
+        /// The repository path where the conflict occurred.
+        path: String,
+    },
+
+    /// Git reported an authentication failure.
+    #[error("authentication failed for remote in {path} — check your SSH keys or credential manager")]
+    AuthFailed {
+        /// The repository path.
+        path: String,
+    },
+
+    /// A network error prevented the git operation from completing.
+    #[error("network error in {path} — check your connection and try again")]
+    NetworkError {
+        /// The repository path.
+        path: String,
+    },
+
+    /// The git binary was not found on the system.
+    #[error("git is not installed or not in PATH")]
+    GitNotFound,
+
+    /// A git command failed with an unrecognized error.
+    #[error("git {operation} failed in {path}: {message}")]
+    Command {
+        /// Which git subcommand was run.
+        operation: String,
+        /// The repository path.
+        path: String,
+        /// The stderr output from git.
+        message: String,
+    },
+}
+
+/// Check whether `git` is available on the system PATH.
+pub fn is_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Returns `true` if the working tree at `repo` has no uncommitted changes.
+pub fn is_clean(repo: &Path) -> Result<bool, Error> {
+    ensure_repo(repo)?;
+
+    let output = run_git(repo, &["status", "--porcelain"])?;
+    Ok(output.trim().is_empty())
+}
+
+/// Stage all changes and commit with the given message.
+///
+/// Returns [`CommitOutcome::NothingToCommit`] if the working tree is already
+/// clean, rather than treating it as an error.
+pub fn commit(repo: &Path, message: &str) -> Result<CommitOutcome, Error> {
+    ensure_repo(repo)?;
+
+    if is_clean(repo)? {
+        return Ok(CommitOutcome::NothingToCommit);
+    }
+
+    run_git(repo, &["add", "--all"])?;
+    run_git(repo, &["commit", "-m", message])?;
+
+    Ok(CommitOutcome::Committed)
+}
+
+/// Clone a repository from `url` to `dest`.
+pub fn clone(url: &str, dest: &Path) -> Result<(), Error> {
+    let output = Command::new("git")
+        .args(["clone", url])
+        .arg(dest)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let dest_str = dest.display().to_string();
+        return Err(classify_error("clone", &dest_str, &stderr));
+    }
+
+    Ok(())
+}
+
+/// Pull with `--rebase` from the tracking remote.
+pub fn pull(repo: &Path) -> Result<(), Error> {
+    ensure_repo(repo)?;
+
+    let output = Command::new("git")
+        .args(["pull", "--rebase"])
+        .current_dir(repo)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let path = repo.display().to_string();
+        return Err(classify_error("pull", &path, &stderr));
+    }
+
+    Ok(())
+}
+
+/// Push the current branch to the tracking remote.
+pub fn push(repo: &Path) -> Result<(), Error> {
+    ensure_repo(repo)?;
+
+    let output = Command::new("git")
+        .args(["push"])
+        .current_dir(repo)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let path = repo.display().to_string();
+        return Err(classify_error("push", &path, &stderr));
+    }
+
+    Ok(())
+}
+
+// --- internal helpers ---
+
+/// Verify that `path` is inside a git repository.
+fn ensure_repo(path: &Path) -> Result<(), Error> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(path)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if !output.status.success() {
+        return Err(Error::NotARepo {
+            path: path.display().to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Run a git command in `repo` and return its stdout on success.
+fn run_git(repo: &Path, args: &[&str]) -> Result<String, Error> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let operation = args.first().copied().unwrap_or("unknown").to_string();
+        let path = repo.display().to_string();
+        return Err(classify_error(&operation, &path, &stderr));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Classify a git stderr message into a typed error variant.
+fn classify_error(operation: &str, path: &str, stderr: &str) -> Error {
+    let lower = stderr.to_lowercase();
+
+    if lower.contains("conflict") || lower.contains("could not apply") {
+        return Error::MergeConflict {
+            path: path.to_string(),
+        };
+    }
+
+    if lower.contains("authentication")
+        || lower.contains("permission denied")
+        || lower.contains("could not read from remote")
+    {
+        return Error::AuthFailed {
+            path: path.to_string(),
+        };
+    }
+
+    if lower.contains("could not resolve host")
+        || lower.contains("unable to access")
+        || lower.contains("connection refused")
+        || lower.contains("network is unreachable")
+    {
+        return Error::NetworkError {
+            path: path.to_string(),
+        };
+    }
+
+    Error::Command {
+        operation: operation.to_string(),
+        path: path.to_string(),
+        message: stderr.trim().to_string(),
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -86,14 +86,33 @@ pub fn is_clean(repo: &Path) -> Result<bool, Error> {
 pub fn commit(repo: &Path, message: &str) -> Result<CommitOutcome, Error> {
     ensure_repo(repo)?;
 
-    if is_clean(repo)? {
+    run_git(repo, &["add", "--all"])?;
+
+    let output = Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(repo)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if output.status.success() {
+        return Ok(CommitOutcome::Committed);
+    }
+
+    // git commit exits non-zero when there's nothing to commit — detect that
+    // from stdout/stderr rather than treating it as a hard error.
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let lower = combined.to_lowercase();
+
+    if lower.contains("nothing to commit") || lower.contains("nothing added to commit") {
         return Ok(CommitOutcome::NothingToCommit);
     }
 
-    run_git(repo, &["add", "--all"])?;
-    run_git(repo, &["commit", "-m", message])?;
-
-    Ok(CommitOutcome::Committed)
+    let path = repo.display().to_string();
+    Err(classify_error("commit", &path, combined.trim()))
 }
 
 /// Clone a repository from `url` to `dest`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,6 @@ pub mod reconcile;
 
 /// Persistent state tracking what nostos has applied on this machine.
 pub mod state;
+
+/// Git CLI wrapper for clone, commit, pull, push, and status operations.
+pub mod git;

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -1,0 +1,302 @@
+//! Integration tests for the `git` module.
+//!
+//! These tests shell out to real `git` — they will be skipped if `git` is not
+//! available on the system.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+use nostos::git;
+
+/// Skip the test if git is not installed.
+macro_rules! require_git {
+    () => {
+        if !git::is_available() {
+            eprintln!("skipping: git not found in PATH");
+            return;
+        }
+    };
+}
+
+/// Create a fresh git repo in a temp dir with user config set.
+fn init_repo(dir: &Path) {
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .expect("git init failed");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .expect("git config user.name failed");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.local"])
+        .current_dir(dir)
+        .output()
+        .expect("git config user.email failed");
+}
+
+/// Create a bare remote repo and clone it into a working directory, returning
+/// both temp dirs and the working path.
+fn setup_remote_and_clone() -> (TempDir, TempDir) {
+    let remote_dir = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["init", "--bare", "-b", "main"])
+        .current_dir(remote_dir.path())
+        .output()
+        .expect("git init --bare failed");
+
+    let work_dir = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["clone", remote_dir.path().to_str().unwrap(), "."])
+        .current_dir(work_dir.path())
+        .output()
+        .expect("git clone failed");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(work_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@test.local"])
+        .current_dir(work_dir.path())
+        .output()
+        .unwrap();
+
+    (remote_dir, work_dir)
+}
+
+// --- Tracer bullet: is_clean on a clean repo ---
+
+#[test]
+fn is_clean_returns_true_on_clean_repo() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    init_repo(dir.path());
+
+    // Make an initial commit so HEAD exists
+    fs::write(dir.path().join("README.md"), "hello").unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(git::is_clean(dir.path()).unwrap());
+}
+
+#[test]
+fn is_clean_returns_false_when_files_modified() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    init_repo(dir.path());
+
+    fs::write(dir.path().join("README.md"), "hello").unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Now modify a file
+    fs::write(dir.path().join("README.md"), "changed").unwrap();
+    assert!(!git::is_clean(dir.path()).unwrap());
+}
+
+#[test]
+fn commit_stages_and_commits_changes() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    init_repo(dir.path());
+
+    fs::write(dir.path().join("file.txt"), "content").unwrap();
+    let result = git::commit(dir.path(), "add file").unwrap();
+    assert_eq!(result, git::CommitOutcome::Committed);
+    assert!(git::is_clean(dir.path()).unwrap());
+}
+
+#[test]
+fn commit_returns_nothing_to_commit_on_clean_tree() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    init_repo(dir.path());
+
+    fs::write(dir.path().join("file.txt"), "content").unwrap();
+    git::commit(dir.path(), "initial").unwrap();
+
+    let result = git::commit(dir.path(), "should be noop").unwrap();
+    assert_eq!(result, git::CommitOutcome::NothingToCommit);
+}
+
+#[test]
+fn clone_creates_working_copy() {
+    require_git!();
+    let remote_dir = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["init", "--bare", "-b", "main"])
+        .current_dir(remote_dir.path())
+        .output()
+        .expect("git init --bare failed");
+
+    let dest_dir = TempDir::new().unwrap();
+    let clone_path = dest_dir.path().join("repo");
+
+    git::clone(remote_dir.path().to_str().unwrap(), &clone_path).unwrap();
+    assert!(clone_path.join(".git").exists());
+}
+
+#[test]
+fn pull_fast_forward_succeeds() {
+    require_git!();
+    let (remote_dir, work_dir) = setup_remote_and_clone();
+
+    // Push an initial commit from a second clone so there's something to pull
+    let pusher_dir = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["clone", remote_dir.path().to_str().unwrap(), "."])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Pusher"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "pusher@test.local"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    fs::write(pusher_dir.path().join("file.txt"), "from pusher").unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "upstream commit"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+
+    // Now pull from the original working copy
+    git::pull(work_dir.path()).unwrap();
+    assert!(work_dir.path().join("file.txt").exists());
+}
+
+#[test]
+fn pull_with_conflict_returns_merge_conflict_error() {
+    require_git!();
+    let (remote_dir, work_dir) = setup_remote_and_clone();
+
+    // Push an initial commit from a second clone
+    let pusher_dir = TempDir::new().unwrap();
+    Command::new("git")
+        .args(["clone", remote_dir.path().to_str().unwrap(), "."])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Pusher"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "pusher@test.local"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    fs::write(pusher_dir.path().join("file.txt"), "version A").unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "A"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["push"])
+        .current_dir(pusher_dir.path())
+        .output()
+        .unwrap();
+
+    // Create a conflicting commit locally
+    fs::write(work_dir.path().join("file.txt"), "version B").unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(work_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "B"])
+        .current_dir(work_dir.path())
+        .output()
+        .unwrap();
+
+    let err = git::pull(work_dir.path()).unwrap_err();
+    assert!(
+        matches!(err, git::Error::MergeConflict { .. }),
+        "expected MergeConflict, got: {err:?}"
+    );
+
+    // Clean up the failed rebase so temp dir can be deleted
+    Command::new("git")
+        .args(["rebase", "--abort"])
+        .current_dir(work_dir.path())
+        .output()
+        .ok();
+}
+
+#[test]
+fn push_sends_commits_to_remote() {
+    require_git!();
+    let (_remote_dir, work_dir) = setup_remote_and_clone();
+
+    fs::write(work_dir.path().join("pushed.txt"), "data").unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(work_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "to push"])
+        .current_dir(work_dir.path())
+        .output()
+        .unwrap();
+
+    git::push(work_dir.path()).unwrap();
+}
+
+#[test]
+fn not_a_repo_returns_typed_error() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    // dir is NOT a git repo
+
+    let err = git::is_clean(dir.path()).unwrap_err();
+    assert!(
+        matches!(err, git::Error::NotARepo { .. }),
+        "expected NotARepo, got: {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements #30 — a `git` module that shells out to the `git` CLI for all repository operations (per ADR 0001).

### Public API

- `clone(url, path)` — clone a repository
- `commit(repo, message)` — stage all + commit; returns `NothingToCommit` on clean trees
- `pull(repo)` — `git pull --rebase` with merge conflict detection
- `push(repo)` — push to tracking remote
- `is_clean(repo)` — check for uncommitted changes
- `is_available()` — check if git is installed (for CI skip)

### Error handling

Typed `Error` enum with dedicated variants for common failures:
- `NotARepo` / `MergeConflict` / `AuthFailed` / `NetworkError` / `GitNotFound` / `Command`
- Each variant includes actionable recovery guidance in its `Display` message

### Testing

9 integration tests using real temp-dir git repos (no network, no mocking). Tests skip gracefully if `git` is not in PATH.

Closes #30