### PR TITLE
feat: implement platform/machine layering for dotfiles (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,55 @@ Requires Rust 1.95+ (edition 2024).
   (e.g., `~/.bashrc.nostos-backup-20260501-121500`), never silent
   overwrites.
 
+- **Platform/machine layering** — override specific files per OS or per
+  machine. The cascade (base → platform → machine) means machine-specific
+  configs always win.
+
+## Platform and machine overrides
+
+nostos supports platform-specific and machine-specific dotfile overrides.
+Base files come from the source directory walk. Platform and machine
+overrides replace or add files using explicit mappings in `nostos.toml`.
+
+```toml
+[dotfiles]
+source = "dotfiles/"
+target = "~"
+
+# Override gitconfig on Linux (e.g., different credential helper)
+[dotfiles.platforms.linux]
+"gitconfig" = "dotfiles/platforms/linux/gitconfig"
+
+# Machine-specific git identity and SSH config
+[dotfiles.machines.work-macbook]
+"gitconfig" = "dotfiles/machines/work-macbook/gitconfig"
+"ssh/config" = "dotfiles/machines/work-macbook/ssh-config"
+```
+
+Corresponding repo layout:
+
+```
+my-env-repo/
+├── nostos.toml
+└── dotfiles/
+    ├── bashrc
+    ├── gitconfig
+    ├── platforms/
+    │   └── linux/
+    │       └── gitconfig
+    └── machines/
+        └── work-macbook/
+            ├── gitconfig
+            └── ssh-config
+```
+
+**Cascade order:** base → platform → machine. If the same target path
+appears at multiple layers, machine wins over platform wins over base.
+Overrides replace or add entries but never remove base files.
+
+**Machine identity** is auto-detected from hostname and stored in
+`state.toml`.
+
 ## Commands
 
 | Command  | Description                                        | Exit codes           |
@@ -134,6 +183,7 @@ cargo clippy --all-targets
 
 What works today:
 - Dotfile sync with conflict detection and safe backups
+- Platform/machine dotfile layering with cascade overrides
 - Full config schema validation (tools, hooks, files, preferences)
 - Cross-platform (Linux, macOS, Windows)
 - Package manager discovery

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,9 +25,7 @@ works end-to-end.
 - Tool resolver and installer registry
   - Per-distro installer preferences
 - Hook executor
-- Platform/machine layering and overrides
-  - Dotfile platform overrides (`[dotfiles.platforms.*]`)
-  - Machine-specific dotfile overrides (`[dotfiles.machines.*]`)
+- Platform/machine layering for hooks and tools
 - `nostos init` (git clone via libgit2)
 - `nostos sync` (commit/push/pull)
 - `nostos track` (reverse sync)
@@ -53,10 +51,12 @@ src/
 ├── config/              ← configuration parsing and merging
 │   ├── mod.rs           ← top-level Config struct
 │   ├── dotfiles.rs      ← dotfile config types
+│   ├── files.rs         ← files config types
 │   ├── tools.rs         ← tool config types
 │   └── hooks.rs         ← hook config types
 ├── reconcile/           ← applying desired state to the machine
 │   ├── mod.rs           ← reconciler orchestration
+│   ├── filemap.rs       ← file map builder (base → platform → machine cascade)
 │   ├── dotfiles.rs      ← copy files, detect conflicts
 │   ├── tools.rs         ← resolve and install tools
 │   └── hooks.rs         ← run hook scripts
@@ -86,13 +86,13 @@ the first build acts on.
 source = "dotfiles/"                    # required, path relative to repo root
 target = "~"                            # required, target directory
 
-# post-MVP: platform-specific overrides (requires platform/machine layering)
-# Keys are repo-relative paths (without leading dot).
-# Values are alternate source paths.
+# Platform-specific overrides.
+# Keys are target-relative paths (without leading dot).
+# Values are repo-relative source paths.
 [dotfiles.platforms.<platform>]         # optional, platform = macos|linux|windows
 "<target-path>" = "<source-path>"
 
-# post-MVP: machine-specific overrides (requires platform/machine layering)
+# Machine-specific overrides.
 # Same key/value format as platform overrides.
 [dotfiles.machines.<machine-id>]        # optional
 "<target-path>" = "<source-path>"
@@ -140,7 +140,7 @@ following sections drive behaviour in the first build:
 
 | Section | MVP behaviour |
 |---------|---------------|
-| `[dotfiles]` (source, target) | Copy-based placement with dot-prepend |
+| `[dotfiles]` (source, target, platforms, machines) | Copy-based placement with dot-prepend, platform/machine override cascade |
 | Everything else | Rejected with a diagnostic ("not yet supported") |
 
 ### Field types
@@ -204,13 +204,15 @@ id = "work-macbook"                    # set at init time
 # order = 1
 
 [applied]
-# Key: target path (with dot), Value: hash + timestamp of last apply
-".bashrc" = { hash = "sha256:...", timestamp = "2026-04-26T20:00:00Z" }
-".config/starship.toml" = { hash = "sha256:...", timestamp = "2026-04-25T10:30:00Z" }
+# Key: target path (with dot)
+# Value: hash, timestamp, and repo-relative source path of last apply
+".bashrc" = { hash = "sha256:...", timestamp = "2026-04-26T20:00:00Z", source = "dotfiles/bashrc" }
+".config/starship.toml" = { hash = "sha256:...", timestamp = "2026-04-25T10:30:00Z", source = "dotfiles/config/starship.toml" }
 
-# Post-MVP: entries gain a `source` field for repo attribution
-# ".bashrc" = { hash = "sha256:...", timestamp = "...", source = "dotfiles" }
-# ".config/starship.toml" = { hash = "sha256:...", timestamp = "...", source = "work-dotfiles" }
+# When multi-repo is enabled (post-MVP), `source` disambiguates which
+# repo a file came from:
+# ".bashrc" = { hash = "sha256:...", timestamp = "...", source = "dotfiles/bashrc" }
+# ".config/starship.toml" = { hash = "sha256:...", timestamp = "...", source = "dotfiles/config/starship.toml" }
 ```
 
 ## Error handling

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -1293,7 +1293,6 @@ ignored by git.
 │         │   Layering / Merge    │           │
 │         │  per-repo: base →     │           │
 │         │    platform → machine │           │
-│         │    (post-MVP)         │           │
 │         │  cross-repo: ordered  │           │
 │         │    merge (post-MVP)   │           │
 │         └───────────────────────┘           │

--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -17,7 +17,10 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     state.ensure_machine_identity();
     let repo_root = config::repo_root_from_config(&config_path);
 
-    let report = match reconcile::apply(&cfg, &mut state, &repo_root) {
+    let platform = crate::platform::detect().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let machine_id = state.machine_id().map(|s| s.to_string());
+
+    let report = match reconcile::apply(&cfg, &mut state, &repo_root, &platform, machine_id.as_deref()) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {e}");

--- a/src/cli/plan.rs
+++ b/src/cli/plan.rs
@@ -16,7 +16,10 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     let state = State::load().unwrap_or_default();
     let repo_root = config::repo_root_from_config(&config_path);
 
-    let report = match reconcile::plan(&cfg, &state, &repo_root) {
+    let platform = crate::platform::detect().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let machine_id = state.machine_id().map(|s| s.to_string());
+
+    let report = match reconcile::plan(&cfg, &state, &repo_root, &platform, machine_id.as_deref()) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {e}");

--- a/src/config/dotfiles.rs
+++ b/src/config/dotfiles.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 /// Configuration for the `[dotfiles]` section.
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -6,4 +8,12 @@ pub struct DotfilesConfig {
     pub source: String,
     /// Target directory where dotfiles are placed (e.g., "~").
     pub target: String,
+    /// Platform-specific overrides: `[dotfiles.platforms.<os>]` maps
+    /// target-relative paths to alternate source paths in the repo.
+    #[serde(default)]
+    pub platforms: HashMap<String, HashMap<String, String>>,
+    /// Machine-specific overrides: `[dotfiles.machines.<id>]` maps
+    /// target-relative paths to alternate source paths in the repo.
+    #[serde(default)]
+    pub machines: HashMap<String, HashMap<String, String>>,
 }

--- a/src/config/files.rs
+++ b/src/config/files.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 /// Configuration for the `[files]` section (verbatim copy, no dot-prepend).
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -6,4 +8,12 @@ pub struct FilesConfig {
     pub source: String,
     /// Target directory.
     pub target: String,
+    /// Platform-specific overrides: `[files.platforms.<os>]` maps
+    /// target-relative paths to alternate source paths in the repo.
+    #[serde(default)]
+    pub platforms: HashMap<String, HashMap<String, String>>,
+    /// Machine-specific overrides: `[files.machines.<id>]` maps
+    /// target-relative paths to alternate source paths in the repo.
+    #[serde(default)]
+    pub machines: HashMap<String, HashMap<String, String>>,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -434,6 +434,97 @@ mod tests {
     }
 
     #[test]
+    fn config_with_dotfiles_platform_overrides() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [dotfiles.platforms.linux]
+            "config/alacritty.toml" = "dotfiles/platforms/linux/alacritty.toml"
+
+            [dotfiles.platforms.macos]
+            "config/alacritty.toml" = "dotfiles/platforms/macos/alacritty.toml"
+            "#,
+        )
+        .expect("should parse");
+        let df = config.dotfiles.expect("dotfiles present");
+        assert_eq!(df.platforms.len(), 2);
+        assert!(df.platforms.contains_key("linux"));
+        assert!(df.platforms.contains_key("macos"));
+        assert_eq!(
+            df.platforms["linux"]["config/alacritty.toml"],
+            "dotfiles/platforms/linux/alacritty.toml"
+        );
+    }
+
+    #[test]
+    fn config_with_dotfiles_machine_overrides() {
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [dotfiles.machines.work-macbook]
+            "gitconfig" = "dotfiles/machines/work-macbook/gitconfig"
+            "#,
+        )
+        .expect("should parse");
+        let df = config.dotfiles.expect("dotfiles present");
+        assert_eq!(df.machines.len(), 1);
+        assert_eq!(
+            df.machines["work-macbook"]["gitconfig"],
+            "dotfiles/machines/work-macbook/gitconfig"
+        );
+    }
+
+    #[test]
+    fn config_with_files_platform_and_machine_overrides() {
+        let config = parse_str(
+            r#"
+            [files]
+            source = "files/"
+            target = "~"
+
+            [files.platforms.linux]
+            "bin/open" = "files/platforms/linux/open"
+
+            [files.machines.work-macbook]
+            "bin/vpn" = "files/machines/work-macbook/vpn"
+            "#,
+        )
+        .expect("should parse");
+        let files = config.files.expect("files present");
+        assert_eq!(files.platforms.len(), 1);
+        assert_eq!(files.machines.len(), 1);
+    }
+
+    #[test]
+    fn config_without_overrides_still_parses() {
+        // Existing configs with no platforms/machines should still work
+        let config = parse_str(
+            r#"
+            [dotfiles]
+            source = "dotfiles/"
+            target = "~"
+
+            [files]
+            source = "files/"
+            target = "~"
+            "#,
+        )
+        .expect("should parse");
+        let df = config.dotfiles.expect("dotfiles present");
+        assert!(df.platforms.is_empty());
+        assert!(df.machines.is_empty());
+        let files = config.files.expect("files present");
+        assert!(files.platforms.is_empty());
+        assert!(files.machines.is_empty());
+    }
+
+    #[test]
     fn repo_root_from_bare_filename_uses_cwd() {
         let path = Path::new("nostos.toml");
         let root = repo_root_from_config(path);

--- a/src/reconcile/dotfiles.rs
+++ b/src/reconcile/dotfiles.rs
@@ -92,8 +92,11 @@ pub fn plan(
     config: &crate::config::dotfiles::DotfilesConfig,
     state: &State,
     repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    plan_inner(&config.source, &config.target, true, state, repo_root)
+    let input = super::filemap::FileMapInput::from(config);
+    plan_inner(&input, &config.target, true, state, repo_root, platform, machine_id)
 }
 
 /// Execute dotfiles (with dot-prepend convention).
@@ -101,8 +104,11 @@ pub fn apply(
     config: &crate::config::dotfiles::DotfilesConfig,
     state: &mut State,
     repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    apply_inner(&config.source, &config.target, true, state, repo_root)
+    let input = super::filemap::FileMapInput::from(config);
+    apply_inner(&input, &config.target, true, state, repo_root, platform, machine_id)
 }
 
 /// Build a plan for verbatim files (no dot-prepend).
@@ -110,8 +116,11 @@ pub fn plan_files(
     config: &crate::config::files::FilesConfig,
     state: &State,
     repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    plan_inner(&config.source, &config.target, false, state, repo_root)
+    let input = super::filemap::FileMapInput::from(config);
+    plan_inner(&input, &config.target, false, state, repo_root, platform, machine_id)
 }
 
 /// Execute verbatim files (no dot-prepend).
@@ -119,36 +128,72 @@ pub fn apply_files(
     config: &crate::config::files::FilesConfig,
     state: &mut State,
     repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    apply_inner(&config.source, &config.target, false, state, repo_root)
+    let input = super::filemap::FileMapInput::from(config);
+    apply_inner(&input, &config.target, false, state, repo_root, platform, machine_id)
 }
 
-/// Shared plan logic: walk source tree, classify each file.
+/// Shared plan logic: build file map, classify each file.
 fn plan_inner(
-    source: &str,
+    input: &super::filemap::FileMapInput,
     target: &str,
     prepend_dot: bool,
     state: &State,
     repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    let source_dir = repo_root.join(source);
+    let source_dir = repo_root.join(input.source);
     check_source_dir(&source_dir)?;
 
     let target_base = expand_tilde(target)?;
     let mut report = Report::default();
 
-    let (files, skips) = walk_source_dir(&source_dir)?;
-    report.errors.extend(skips);
-    for rel_path in files {
-        let src = source_dir.join(&rel_path);
+    let (file_map, diagnostics) =
+        super::filemap::build(input, repo_root, platform, machine_id)?;
+
+    // Report diagnostics as errors/warnings
+    for diag in &diagnostics {
+        match diag {
+            super::filemap::Diagnostic::MissingSource { layer, target, source } => {
+                report.errors.push(format!(
+                    "override source not found: {} (layer: {layer}, target: {target})",
+                    source.display()
+                ));
+            }
+            super::filemap::Diagnostic::UnknownPlatform { name } => {
+                report.errors.push(format!(
+                    "unknown platform name in config: {name} (known: linux, macos, windows)"
+                ));
+            }
+            super::filemap::Diagnostic::WalkSkip(msg) => {
+                report.errors.push(msg.clone());
+            }
+            super::filemap::Diagnostic::SourceOutsideRepo { layer, target, source } => {
+                report.errors.push(format!(
+                    "override source outside repo: {} (layer: {layer}, target: {target})",
+                    source.display()
+                ));
+            }
+        }
+    }
+
+    // Sort keys for deterministic output
+    let mut targets: Vec<_> = file_map.keys().collect();
+    targets.sort();
+
+    for rel_path in targets {
+        let src = &file_map[rel_path];
         let target_rel = if prepend_dot {
-            dot_prepend(&rel_path)
+            dot_prepend(rel_path)
         } else {
-            rel_path
+            rel_path.clone()
         };
         let tgt = target_base.join(&target_rel);
 
-        match classify(&src, &tgt, &target_rel, state) {
+        match classify(src, &tgt, &target_rel, state) {
             Ok(action) => report.actions.push(action),
             Err(msg) => report.errors.push(msg),
         }
@@ -157,32 +202,68 @@ fn plan_inner(
     Ok(report)
 }
 
-/// Shared apply logic: walk source tree, classify and execute each file.
+/// Shared apply logic: build file map, classify and execute each file.
 fn apply_inner(
-    source: &str,
+    input: &super::filemap::FileMapInput,
     target: &str,
     prepend_dot: bool,
     state: &mut State,
     repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    let source_dir = repo_root.join(source);
+    let source_dir = repo_root.join(input.source);
     check_source_dir(&source_dir)?;
 
     let target_base = expand_tilde(target)?;
     let mut report = Report::default();
 
-    let (files, skips) = walk_source_dir(&source_dir)?;
-    report.errors.extend(skips);
-    for rel_path in files {
-        let src = source_dir.join(&rel_path);
+    let (file_map, diagnostics) =
+        super::filemap::build(input, repo_root, platform, machine_id)?;
+
+    for diag in &diagnostics {
+        match diag {
+            super::filemap::Diagnostic::MissingSource { layer, target, source } => {
+                report.errors.push(format!(
+                    "override source not found: {} (layer: {layer}, target: {target})",
+                    source.display()
+                ));
+            }
+            super::filemap::Diagnostic::UnknownPlatform { name } => {
+                report.errors.push(format!(
+                    "unknown platform name in config: {name} (known: linux, macos, windows)"
+                ));
+            }
+            super::filemap::Diagnostic::WalkSkip(msg) => {
+                report.errors.push(msg.clone());
+            }
+            super::filemap::Diagnostic::SourceOutsideRepo { layer, target, source } => {
+                report.errors.push(format!(
+                    "override source outside repo: {} (layer: {layer}, target: {target})",
+                    source.display()
+                ));
+            }
+        }
+    }
+
+    let mut targets: Vec<_> = file_map.keys().collect();
+    targets.sort();
+
+    for rel_path in targets {
+        let src = &file_map[rel_path];
         let target_rel = if prepend_dot {
-            dot_prepend(&rel_path)
+            dot_prepend(rel_path)
         } else {
-            rel_path
+            rel_path.clone()
         };
         let tgt = target_base.join(&target_rel);
 
-        let action = match classify(&src, &tgt, &target_rel, state) {
+        // Compute repo-relative source path for state tracking
+        let source_rel = src.strip_prefix(repo_root)
+            .map(|p| p.to_string_lossy().to_string())
+            .ok();
+
+        let action = match classify(src, &tgt, &target_rel, state) {
             Ok(action) => action,
             Err(msg) => {
                 report.errors.push(msg);
@@ -204,6 +285,7 @@ fn apply_inner(
                     AppliedEntry {
                         hash: source_hash.clone(),
                         timestamp: chrono::Utc::now(),
+                        source: source_rel,
                     },
                 );
             }
@@ -213,7 +295,6 @@ fn apply_inner(
                 backup,
                 source_hash,
             } => {
-                // Back up the existing file first
                 if let Err(e) = std::fs::copy(target, backup) {
                     report.errors.push(format!(
                         "failed to back up {}: {e}",
@@ -230,6 +311,7 @@ fn apply_inner(
                     AppliedEntry {
                         hash: source_hash.clone(),
                         timestamp: chrono::Utc::now(),
+                        source: source_rel,
                     },
                 );
             }
@@ -356,7 +438,7 @@ fn check_source_dir(source_dir: &Path) -> Result<(), Error> {
 /// in the dotfiles tree pointing at, e.g., `/etc/passwd` would otherwise be
 /// dereferenced by `std::fs::copy` and written into the user's home as a
 /// regular file.
-fn walk_source_dir(dir: &Path) -> Result<(Vec<String>, Vec<String>), Error> {
+pub(crate) fn walk_source_dir(dir: &Path) -> Result<(Vec<String>, Vec<String>), Error> {
     let mut files = Vec::new();
     let mut skips = Vec::new();
     walk_recursive(dir, dir, &mut files, &mut skips)?;
@@ -506,6 +588,8 @@ mod tests {
             DotfilesConfig {
                 source: "dotfiles/".to_string(),
                 target: self.target_dir.to_string_lossy().to_string(),
+                platforms: Default::default(),
+                machines: Default::default(),
             }
         }
 
@@ -544,12 +628,22 @@ mod tests {
                 AppliedEntry {
                     hash: format!("sha256:{:x}", digest),
                     timestamp: chrono::Utc::now(),
+                    source: None,
                 },
             )
         }
     }
 
     // ── Plan tests ──────────────────────────────────────────
+
+    fn test_platform() -> crate::platform::Platform {
+        crate::platform::Platform {
+            os: crate::platform::Os::Linux,
+            arch: crate::platform::Arch::X86_64,
+            distro: None,
+            managers: vec![],
+        }
+    }
 
     #[test]
     fn plan_new_file() {
@@ -558,7 +652,7 @@ mod tests {
         let state = repo.load_state();
         let config = repo.config();
 
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(&report.actions[0], DotfileAction::NewFile { .. }));
     }
@@ -573,7 +667,7 @@ mod tests {
         state.applied.insert(key, entry);
 
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -591,7 +685,7 @@ mod tests {
         state.applied.insert(key, entry);
 
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -609,7 +703,7 @@ mod tests {
         state.applied.insert(key, entry);
 
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -627,7 +721,7 @@ mod tests {
         state.applied.insert(key, entry);
 
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -643,7 +737,7 @@ mod tests {
         let state = State::default(); // no state entry
 
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -659,7 +753,7 @@ mod tests {
         let state = State::default();
         let config = repo.config();
 
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 2);
         assert!(report
             .actions
@@ -674,7 +768,7 @@ mod tests {
         let state = State::default();
         let config = repo.config();
 
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         match &report.actions[0] {
             DotfileAction::NewFile { target, .. } => {
@@ -690,7 +784,7 @@ mod tests {
         let state = State::default();
         let config = repo.config();
 
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert!(report.actions.is_empty());
     }
 
@@ -700,10 +794,12 @@ mod tests {
         let config = DotfilesConfig {
             source: "nonexistent/".to_string(),
             target: repo.target_dir.to_string_lossy().to_string(),
+            platforms: Default::default(),
+            machines: Default::default(),
         };
         let state = State::default();
         assert!(matches!(
-            plan(&config, &state, &repo.repo_root),
+            plan(&config, &state, &repo.repo_root, &test_platform(), None),
             Err(Error::SourceNotFound(_))
         ));
     }
@@ -718,7 +814,7 @@ mod tests {
         state.applied.insert(key, entry);
 
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -735,7 +831,7 @@ mod tests {
         let state = State::default();
         let config = repo.config();
 
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
         assert!(!report.errors.is_empty());
         assert!(report.actions.is_empty());
     }
@@ -747,7 +843,7 @@ mod tests {
         let state = State::default();
         let config = repo.config();
 
-        plan(&config, &state, &repo.repo_root).unwrap();
+        plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
 
         // Verify target was NOT created
         assert!(!repo.target_exists(".bashrc"));
@@ -762,7 +858,7 @@ mod tests {
         let mut state = State::default();
         let config = repo.config();
 
-        let report = apply(&config, &mut state, &repo.repo_root).unwrap();
+        let report = apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -779,7 +875,7 @@ mod tests {
         let mut state = State::default();
         let config = repo.config();
 
-        apply(&config, &mut state, &repo.repo_root).unwrap();
+        apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(
             repo.read_target(".config/alacritty/alacritty.toml"),
             "config content"
@@ -796,7 +892,7 @@ mod tests {
         state.applied.insert(key, entry);
         let config = repo.config();
 
-        let report = apply(&config, &mut state, &repo.repo_root).unwrap();
+        let report = apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
 
         // Target should have repo content
         assert_eq!(repo.read_target(".bashrc"), "# repo version 2");
@@ -819,10 +915,10 @@ mod tests {
         let config = repo.config();
 
         // First apply
-        apply(&config, &mut state, &repo.repo_root).unwrap();
+        apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
 
         // Second apply — should be all up to date
-        let report = apply(&config, &mut state, &repo.repo_root).unwrap();
+        let report = apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
         assert_eq!(report.actions.len(), 1);
         assert!(matches!(
             &report.actions[0],
@@ -840,7 +936,7 @@ mod tests {
         state.applied.insert(key, entry);
         let config = repo.config();
 
-        let report = apply(&config, &mut state, &repo.repo_root).unwrap();
+        let report = apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
 
         // Should skip — user's file preserved
         assert_eq!(repo.read_target(".bashrc"), "# user edited");
@@ -872,7 +968,7 @@ mod tests {
         state.applied.insert(k3, e3);
 
         let config = repo.config();
-        let report = apply(&config, &mut state, &repo.repo_root).unwrap();
+        let report = apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
 
         assert_eq!(report.actions.len(), 3);
         assert!(report.has_warnings()); // local mod
@@ -887,7 +983,7 @@ mod tests {
         let mut state = State::default();
         let config = repo.config(); // uses absolute target_dir path
 
-        apply(&config, &mut state, &repo.repo_root).unwrap();
+        apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
         assert!(repo.target_exists(".testfile"));
     }
 
@@ -904,7 +1000,7 @@ mod tests {
         let mut state = State::default();
         let config = repo.config();
 
-        apply(&config, &mut state, &repo.repo_root).unwrap();
+        apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
 
         // New file was placed correctly
         assert_eq!(repo.read_target(".config/foo/bar.toml"), "new dotfile content");
@@ -959,7 +1055,7 @@ mod tests {
 
         let state = State::default();
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
 
         assert!(report.actions.is_empty(), "no actions for symlinked source");
         assert!(
@@ -981,7 +1077,7 @@ mod tests {
 
         let mut state = State::default();
         let config = repo.config();
-        let report = apply(&config, &mut state, &repo.repo_root).unwrap();
+        let report = apply(&config, &mut state, &repo.repo_root, &test_platform(), None).unwrap();
 
         assert!(report.actions.is_empty());
         assert!(report.errors.iter().any(|e| e.contains("symlink")));
@@ -1007,7 +1103,7 @@ mod tests {
 
         let state = State::default();
         let config = repo.config();
-        let report = plan(&config, &state, &repo.repo_root).unwrap();
+        let report = plan(&config, &state, &repo.repo_root, &test_platform(), None).unwrap();
 
         // Only the real file should produce an action.
         assert_eq!(report.actions.len(), 1);
@@ -1038,7 +1134,7 @@ mod tests {
 
         let state = State::default();
         let config = repo.config();
-        let result = plan(&config, &state, &repo.repo_root);
+        let result = plan(&config, &state, &repo.repo_root, &test_platform(), None);
         assert!(
             matches!(result, Err(Error::SourceIsSymlink(_))),
             "expected SourceIsSymlink, got {result:?}"

--- a/src/reconcile/filemap.rs
+++ b/src/reconcile/filemap.rs
@@ -1,0 +1,572 @@
+//! File map builder: resolves the base → platform → machine cascade
+//! into a flat target-relative → source-absolute path map.
+//!
+//! This is the core algorithmic module for layering. It takes a config
+//! section (dotfiles or files), the current platform, and an optional
+//! machine identity, then produces the map that drives reconciliation.
+
+use crate::platform::{Os, Platform};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// A diagnostic produced during file map construction.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Diagnostic {
+    /// An override references a source file that does not exist in the repo.
+    MissingSource {
+        layer: String,
+        target: String,
+        source: PathBuf,
+    },
+    /// A platform name in config does not match any known platform.
+    UnknownPlatform {
+        name: String,
+    },
+    /// A file or directory was skipped during the base directory walk
+    /// (e.g., symlinks, unreadable entries).
+    WalkSkip(String),
+    /// An override source path resolves to a location outside the repo root.
+    SourceOutsideRepo {
+        layer: String,
+        target: String,
+        source: PathBuf,
+    },
+}
+
+/// Inputs common to both dotfiles and files sections.
+pub struct FileMapInput<'a> {
+    /// Source directory relative to repo root (e.g., "dotfiles/").
+    pub source: &'a str,
+    /// Platform-specific overrides.
+    pub platforms: &'a HashMap<String, HashMap<String, String>>,
+    /// Machine-specific overrides.
+    pub machines: &'a HashMap<String, HashMap<String, String>>,
+}
+
+impl<'a> From<&'a crate::config::dotfiles::DotfilesConfig> for FileMapInput<'a> {
+    fn from(c: &'a crate::config::dotfiles::DotfilesConfig) -> Self {
+        FileMapInput {
+            source: &c.source,
+            platforms: &c.platforms,
+            machines: &c.machines,
+        }
+    }
+}
+
+impl<'a> From<&'a crate::config::files::FilesConfig> for FileMapInput<'a> {
+    fn from(c: &'a crate::config::files::FilesConfig) -> Self {
+        FileMapInput {
+            source: &c.source,
+            platforms: &c.platforms,
+            machines: &c.machines,
+        }
+    }
+}
+
+/// Build the file map by walking the base source directory and applying
+/// platform and machine overrides.
+///
+/// Returns `(file_map, diagnostics)` where `file_map` maps target-relative
+/// paths to absolute source paths, and `diagnostics` contains warnings
+/// and errors encountered during construction.
+pub fn build(
+    input: &FileMapInput,
+    repo_root: &Path,
+    platform: &Platform,
+    machine_id: Option<&str>,
+) -> Result<(HashMap<String, PathBuf>, Vec<Diagnostic>), super::dotfiles::Error> {
+    let source_dir = repo_root.join(input.source);
+    let mut diagnostics = Vec::new();
+
+    // Walk base directory, excluding reserved override directories
+    let (base_files, skips) = super::dotfiles::walk_source_dir(&source_dir)?;
+
+    // Convert walk skips to diagnostics
+    for skip in skips {
+        diagnostics.push(Diagnostic::WalkSkip(skip));
+    }
+
+    let mut file_map: HashMap<String, PathBuf> = HashMap::new();
+    for rel_path in &base_files {
+        // Skip files under platforms/ and machines/ — those are only
+        // reachable via explicit override mappings.
+        if rel_path.starts_with("platforms/") || rel_path.starts_with("machines/") {
+            continue;
+        }
+        file_map.insert(rel_path.clone(), source_dir.join(rel_path));
+    }
+
+    // Warn on unknown platform names
+    let known_platforms = ["linux", "macos", "windows"];
+    for name in input.platforms.keys() {
+        if !known_platforms.contains(&name.as_str()) {
+            diagnostics.push(Diagnostic::UnknownPlatform { name: name.clone() });
+        }
+    }
+
+    // Apply platform overrides
+    let platform_key = match platform.os {
+        Os::Linux => "linux",
+        Os::MacOs => "macos",
+        Os::Windows => "windows",
+    };
+
+    if let Some(overrides) = input.platforms.get(platform_key) {
+        apply_overrides(&mut file_map, overrides, platform_key, repo_root, &mut diagnostics);
+    }
+
+    // Apply machine overrides
+    if let Some(machine) = machine_id
+        && let Some(overrides) = input.machines.get(machine)
+    {
+        apply_overrides(&mut file_map, overrides, machine, repo_root, &mut diagnostics);
+    }
+
+    Ok((file_map, diagnostics))
+}
+
+/// Apply a set of overrides (from a platform or machine layer) to the file map.
+///
+/// Validates that each override source exists, is not a symlink, and
+/// resolves to a path inside the repository root.
+fn apply_overrides(
+    file_map: &mut HashMap<String, PathBuf>,
+    overrides: &HashMap<String, String>,
+    layer_name: &str,
+    repo_root: &Path,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let canonical_repo = match repo_root.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    for (target, source) in overrides {
+        let source_path = repo_root.join(source);
+
+        // Use symlink_metadata to detect symlinks without following them.
+        let metadata = match std::fs::symlink_metadata(&source_path) {
+            Ok(m) => m,
+            Err(_) => {
+                diagnostics.push(Diagnostic::MissingSource {
+                    layer: layer_name.to_string(),
+                    target: target.clone(),
+                    source: source_path,
+                });
+                continue;
+            }
+        };
+
+        if metadata.file_type().is_symlink() {
+            diagnostics.push(Diagnostic::SourceOutsideRepo {
+                layer: layer_name.to_string(),
+                target: target.clone(),
+                source: source_path,
+            });
+            continue;
+        }
+
+        // Verify the canonical path is inside the repo root.
+        let canonical_source = match source_path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => {
+                diagnostics.push(Diagnostic::MissingSource {
+                    layer: layer_name.to_string(),
+                    target: target.clone(),
+                    source: source_path,
+                });
+                continue;
+            }
+        };
+
+        if !canonical_source.starts_with(&canonical_repo) {
+            diagnostics.push(Diagnostic::SourceOutsideRepo {
+                layer: layer_name.to_string(),
+                target: target.clone(),
+                source: source_path,
+            });
+            continue;
+        }
+
+        file_map.insert(target.clone(), source_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper to set up a test repo for file map tests.
+    struct MapTestRepo {
+        _dir: TempDir,
+        repo_root: PathBuf,
+    }
+
+    impl MapTestRepo {
+        fn new() -> Self {
+            let dir = TempDir::new().unwrap();
+            let repo_root = dir.path().join("repo");
+            fs::create_dir_all(repo_root.join("dotfiles")).unwrap();
+            MapTestRepo { _dir: dir, repo_root }
+        }
+
+        fn add_file(&self, rel_path: &str, content: &str) {
+            let path = self.repo_root.join(rel_path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, content).unwrap();
+        }
+
+        fn linux_platform(&self) -> Platform {
+            Platform {
+                os: Os::Linux,
+                arch: crate::platform::Arch::X86_64,
+                distro: None,
+                managers: vec![],
+            }
+        }
+
+        fn macos_platform(&self) -> Platform {
+            Platform {
+                os: Os::MacOs,
+                arch: crate::platform::Arch::Aarch64,
+                distro: None,
+                managers: vec![],
+            }
+        }
+
+        fn base_input(&self) -> FileMapInput<'static> {
+            // Leaks are fine in tests — avoids lifetime gymnastics
+            let platforms: &'static HashMap<String, HashMap<String, String>> =
+                Box::leak(Box::default());
+            let machines: &'static HashMap<String, HashMap<String, String>> =
+                Box::leak(Box::default());
+            FileMapInput {
+                source: "dotfiles/",
+                platforms,
+                machines,
+            }
+        }
+    }
+
+    #[test]
+    fn base_only_file_map() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/bashrc", "# bash config");
+        repo.add_file("dotfiles/config/starship.toml", "# starship");
+
+        let input = repo.base_input();
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["bashrc"], repo.repo_root.join("dotfiles/bashrc"));
+        assert_eq!(
+            map["config/starship.toml"],
+            repo.repo_root.join("dotfiles/config/starship.toml")
+        );
+    }
+
+    #[test]
+    fn platform_override_replaces_base_file() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/config/alacritty.toml", "# generic");
+        repo.add_file("dotfiles/platforms/linux/alacritty.toml", "# linux version");
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "config/alacritty.toml".to_string(),
+                "dotfiles/platforms/linux/alacritty.toml".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        assert!(diagnostics.is_empty());
+        // The override should replace the base source path
+        assert_eq!(
+            map["config/alacritty.toml"],
+            repo.repo_root.join("dotfiles/platforms/linux/alacritty.toml")
+        );
+    }
+
+    #[test]
+    fn platform_override_not_applied_on_different_platform() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/config/alacritty.toml", "# generic");
+        repo.add_file("dotfiles/platforms/linux/alacritty.toml", "# linux version");
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "config/alacritty.toml".to_string(),
+                "dotfiles/platforms/linux/alacritty.toml".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        // On macOS, the linux override should NOT apply
+        let (map, _) = build(&input, &repo.repo_root, &repo.macos_platform(), None)
+            .expect("should build");
+
+        assert_eq!(
+            map["config/alacritty.toml"],
+            repo.repo_root.join("dotfiles/config/alacritty.toml")
+        );
+    }
+
+    #[test]
+    fn platform_override_adds_new_file() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/bashrc", "# bash");
+        repo.add_file("dotfiles/platforms/linux/xresources", "! X11 resources");
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "xresources".to_string(),
+                "dotfiles/platforms/linux/xresources".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(map.len(), 2); // bashrc + xresources
+        assert_eq!(
+            map["xresources"],
+            repo.repo_root.join("dotfiles/platforms/linux/xresources")
+        );
+    }
+
+    #[test]
+    fn machine_override_replaces_platform_override() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/gitconfig", "# base");
+        repo.add_file("dotfiles/platforms/linux/gitconfig", "# linux");
+        repo.add_file("dotfiles/machines/work-macbook/gitconfig", "# work");
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "gitconfig".to_string(),
+                "dotfiles/platforms/linux/gitconfig".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::from([(
+            "work-macbook".to_string(),
+            HashMap::from([(
+                "gitconfig".to_string(),
+                "dotfiles/machines/work-macbook/gitconfig".to_string(),
+            )]),
+        )]);
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(
+            &input,
+            &repo.repo_root,
+            &repo.linux_platform(),
+            Some("work-macbook"),
+        )
+        .expect("should build");
+
+        assert!(diagnostics.is_empty());
+        // Machine override wins over platform override
+        assert_eq!(
+            map["gitconfig"],
+            repo.repo_root.join("dotfiles/machines/work-macbook/gitconfig")
+        );
+    }
+
+    #[test]
+    fn missing_override_source_produces_error() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/bashrc", "# bash");
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "bashrc".to_string(),
+                "dotfiles/platforms/linux/bashrc".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        // The override should NOT be applied (source doesn't exist)
+        assert_eq!(map["bashrc"], repo.repo_root.join("dotfiles/bashrc"));
+        // Should have a MissingSource diagnostic
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(&diagnostics[0], Diagnostic::MissingSource { layer, target, .. }
+            if layer == "linux" && target == "bashrc"
+        ));
+    }
+
+    #[test]
+    fn unknown_platform_name_produces_warning() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/bashrc", "# bash");
+        repo.add_file("dotfiles/platforms/haiku/bashrc", "# haiku");
+
+        let platforms = HashMap::from([(
+            "haiku".to_string(),
+            HashMap::from([(
+                "bashrc".to_string(),
+                "dotfiles/platforms/haiku/bashrc".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (_map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        assert!(diagnostics.iter().any(|d| matches!(d,
+            Diagnostic::UnknownPlatform { name } if name == "haiku"
+        )));
+    }
+
+    #[test]
+    fn layering_works_for_files_section() {
+        let repo = MapTestRepo::new();
+        fs::create_dir_all(repo.repo_root.join("files")).unwrap();
+        repo.add_file("files/bin/myscript", "#!/bin/sh\n# generic");
+        repo.add_file("files/platforms/linux/bin/open", "#!/bin/sh\nxdg-open");
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "bin/open".to_string(),
+                "files/platforms/linux/bin/open".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "files/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(map.len(), 2); // myscript + bin/open
+        assert_eq!(
+            map["bin/open"],
+            repo.repo_root.join("files/platforms/linux/bin/open")
+        );
+    }
+
+    #[test]
+    fn override_rejects_path_traversal_outside_repo() {
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/bashrc", "# base");
+        // Create a real file outside the repo root that the traversal path resolves to.
+        let outside = repo._dir.path().join("secret.txt");
+        fs::write(&outside, "SECRET").unwrap();
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "bashrc".to_string(),
+                "../secret.txt".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        // The traversal override must be rejected.
+        assert_eq!(map["bashrc"], repo.repo_root.join("dotfiles/bashrc"),
+            "path traversal should not replace the base file");
+        assert!(
+            diagnostics.iter().any(|d| matches!(d, Diagnostic::SourceOutsideRepo { .. })),
+            "expected SourceOutsideRepo diagnostic, got {diagnostics:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn override_rejects_symlink_source() {
+        use std::os::unix::fs::symlink;
+
+        let repo = MapTestRepo::new();
+        repo.add_file("dotfiles/bashrc", "# base");
+        // Create a symlink inside the repo pointing outside it.
+        let outside = repo._dir.path().join("secret.txt");
+        fs::write(&outside, "SECRET").unwrap();
+        fs::create_dir_all(repo.repo_root.join("dotfiles/platforms/linux")).unwrap();
+        symlink(&outside, repo.repo_root.join("dotfiles/platforms/linux/bashrc")).unwrap();
+
+        let platforms = HashMap::from([(
+            "linux".to_string(),
+            HashMap::from([(
+                "bashrc".to_string(),
+                "dotfiles/platforms/linux/bashrc".to_string(),
+            )]),
+        )]);
+        let machines = HashMap::new();
+        let input = FileMapInput {
+            source: "dotfiles/",
+            platforms: &platforms,
+            machines: &machines,
+        };
+
+        let (map, diagnostics) = build(&input, &repo.repo_root, &repo.linux_platform(), None)
+            .expect("should build");
+
+        // Symlink override must be rejected; base file preserved.
+        assert_eq!(map["bashrc"], repo.repo_root.join("dotfiles/bashrc"),
+            "symlink source should not replace the base file");
+        assert!(
+            diagnostics.iter().any(|d| matches!(d, Diagnostic::SourceOutsideRepo { .. })),
+            "expected SourceOutsideRepo diagnostic, got {diagnostics:?}"
+        );
+    }
+}

--- a/src/reconcile/filemap.rs
+++ b/src/reconcile/filemap.rs
@@ -88,12 +88,14 @@ pub fn build(
 
     let mut file_map: HashMap<String, PathBuf> = HashMap::new();
     for rel_path in &base_files {
+        // Normalise to forward slashes so map keys are platform-independent.
+        let normalised = rel_path.replace('\\', "/");
         // Skip files under platforms/ and machines/ — those are only
         // reachable via explicit override mappings.
-        if rel_path.starts_with("platforms/") || rel_path.starts_with("machines/") {
+        if normalised.starts_with("platforms/") || normalised.starts_with("machines/") {
             continue;
         }
-        file_map.insert(rel_path.clone(), source_dir.join(rel_path));
+        file_map.insert(normalised, source_dir.join(rel_path));
     }
 
     // Warn on unknown platform names

--- a/src/reconcile/mod.rs
+++ b/src/reconcile/mod.rs
@@ -1,7 +1,11 @@
 /// Dotfile reconciliation logic.
 pub mod dotfiles;
 
+/// File map builder: base → platform → machine cascade.
+pub mod filemap;
+
 use crate::config::Config;
+use crate::platform::Platform;
 use crate::state::State;
 use std::path::Path;
 
@@ -42,7 +46,13 @@ impl ApplyReport {
 }
 
 /// Build a plan (dry-run) across all phases.
-pub fn plan(config: &Config, state: &State, repo_root: &Path) -> Result<ApplyReport, PlanError> {
+pub fn plan(
+    config: &Config,
+    state: &State,
+    repo_root: &Path,
+    platform: &Platform,
+    machine_id: Option<&str>,
+) -> Result<ApplyReport, PlanError> {
     let mut report = ApplyReport::default();
 
     // Phase 1: Pre-apply hooks (not yet implemented)
@@ -67,14 +77,16 @@ pub fn plan(config: &Config, state: &State, repo_root: &Path) -> Result<ApplyRep
     // Phase 2: Dotfiles (active)
     if let Some(ref dotfiles_config) = config.dotfiles {
         let dotfiles_report =
-            dotfiles::plan(dotfiles_config, state, repo_root).map_err(PlanError::Dotfiles)?;
+            dotfiles::plan(dotfiles_config, state, repo_root, platform, machine_id)
+                .map_err(PlanError::Dotfiles)?;
         report.dotfiles = Some(dotfiles_report);
     }
 
     // Phase 2b: Files (verbatim copy, no dot-prepend)
     if let Some(ref files_config) = config.files {
         let files_report =
-            dotfiles::plan_files(files_config, state, repo_root).map_err(PlanError::Files)?;
+            dotfiles::plan_files(files_config, state, repo_root, platform, machine_id)
+                .map_err(PlanError::Files)?;
         report.files = Some(files_report);
     }
 
@@ -117,6 +129,8 @@ pub fn apply(
     config: &Config,
     state: &mut State,
     repo_root: &Path,
+    platform: &Platform,
+    machine_id: Option<&str>,
 ) -> Result<ApplyReport, ApplyError> {
     let mut report = ApplyReport::default();
 
@@ -141,14 +155,14 @@ pub fn apply(
 
     // Phase 2: Dotfiles (active)
     if let Some(ref dotfiles_config) = config.dotfiles {
-        let dotfiles_report = dotfiles::apply(dotfiles_config, state, repo_root)
+        let dotfiles_report = dotfiles::apply(dotfiles_config, state, repo_root, platform, machine_id)
             .map_err(ApplyError::Dotfiles)?;
         report.dotfiles = Some(dotfiles_report);
     }
 
     // Phase 2b: Files (verbatim copy, no dot-prepend)
     if let Some(ref files_config) = config.files {
-        let files_report = dotfiles::apply_files(files_config, state, repo_root)
+        let files_report = dotfiles::apply_files(files_config, state, repo_root, platform, machine_id)
             .map_err(ApplyError::Files)?;
         report.files = Some(files_report);
     }
@@ -222,11 +236,21 @@ mod tests {
         path.to_string_lossy().replace('\\', "\\\\")
     }
 
+    fn test_platform() -> crate::platform::Platform {
+        crate::platform::Platform {
+            os: crate::platform::Os::Linux,
+            arch: crate::platform::Arch::X86_64,
+            distro: None,
+            managers: vec![],
+        }
+    }
+
     #[test]
     fn plan_empty_config_succeeds() {
         let config = empty_config();
         let state = State::default();
-        let report = plan(&config, &state, Path::new("/nonexistent")).unwrap();
+        let platform = test_platform();
+        let report = plan(&config, &state, Path::new("/nonexistent"), &platform, None).unwrap();
         assert!(report.dotfiles.is_none());
         assert!(report.pending_phases.is_empty());
     }
@@ -251,7 +275,8 @@ mod tests {
         )
         .unwrap();
         let state = State::default();
-        let report = plan(&config, &state, Path::new("/nonexistent")).unwrap();
+        let platform = test_platform();
+        let report = plan(&config, &state, Path::new("/nonexistent"), &platform, None).unwrap();
         assert!(report.dotfiles.is_none());
         assert!(report.files.is_none());
         // Should have: pre-apply hooks, tools, post-apply hooks = 3 pending phases
@@ -286,7 +311,8 @@ mod tests {
         ))
         .unwrap();
         let state = State::default();
-        let report = plan(&config, &state, &repo_root).unwrap();
+        let platform = test_platform();
+        let report = plan(&config, &state, &repo_root, &platform, None).unwrap();
         assert!(report.dotfiles.is_none());
         let files_report = report.files.expect("files report should be present");
         assert_eq!(files_report.actions.len(), 1);
@@ -319,7 +345,8 @@ mod tests {
         ))
         .unwrap();
         let mut state = State::default();
-        let report = apply(&config, &mut state, &repo_root).unwrap();
+        let platform = test_platform();
+        let report = apply(&config, &mut state, &repo_root, &platform, None).unwrap();
         let files_report = report.files.expect("files report should be present");
         assert_eq!(files_report.actions.len(), 1);
         // File should exist at target WITHOUT dot prepend

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -39,6 +39,10 @@ pub struct AppliedEntry {
     pub hash: String,
     /// Timestamp of last apply.
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Repo-relative source path that produced this target file.
+    /// Used by `track` to reverse-map targets back to their source.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 /// Errors that can occur during state operations.
@@ -229,6 +233,7 @@ mod tests {
             AppliedEntry {
                 hash: "sha256:abc123".to_string(),
                 timestamp: Utc::now(),
+                source: None,
             },
         );
 
@@ -279,6 +284,7 @@ mod tests {
                 timestamp: chrono::DateTime::parse_from_rfc3339("2026-04-26T20:00:00Z")
                     .unwrap()
                     .with_timezone(&Utc),
+                source: None,
             },
         );
 
@@ -318,6 +324,7 @@ mod tests {
             AppliedEntry {
                 hash: "sha256:old".to_string(),
                 timestamp: Utc::now(),
+                source: None,
             },
         );
         state.save_to(&path).expect("save");
@@ -342,6 +349,7 @@ mod tests {
                 AppliedEntry {
                     hash: format!("sha256:hash{i}"),
                     timestamp: Utc::now(),
+                    source: None,
                 },
             );
         }
@@ -390,6 +398,7 @@ mod tests {
                         )
                         .unwrap()
                         .with_timezone(&Utc),
+                        source: None,
                     },
                 );
                 toml::to_string_pretty(&state).unwrap()
@@ -521,5 +530,40 @@ mod tests {
         let state: State = toml::from_str(toml_str).unwrap();
         assert!(state.repo.is_none());
         assert_eq!(state.applied.len(), 1);
+    }
+
+    #[test]
+    fn legacy_state_without_source_field_loads() {
+        let toml_str = r#"
+[applied]
+".bashrc" = { hash = "sha256:abc123", timestamp = "2026-04-26T20:00:00Z" }
+"#;
+        let state: State = toml::from_str(toml_str).unwrap();
+        assert!(state.applied[".bashrc"].source.is_none());
+    }
+
+    #[test]
+    fn state_with_source_field_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.toml");
+
+        let mut state = State::default();
+        state.applied.insert(
+            ".bashrc".to_string(),
+            AppliedEntry {
+                hash: "sha256:abc123".to_string(),
+                timestamp: chrono::DateTime::parse_from_rfc3339("2026-04-26T20:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                source: Some("dotfiles/platforms/linux/bashrc".to_string()),
+            },
+        );
+
+        state.save_to(&path).expect("save");
+        let loaded = State::load_from(&path).expect("load");
+        assert_eq!(
+            loaded.applied[".bashrc"].source.as_deref(),
+            Some("dotfiles/platforms/linux/bashrc")
+        );
     }
 }

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -418,7 +418,7 @@ fn workflow_machine_override_wins_over_platform() {
          [dotfiles.platforms.{plat}]\n\
          bashrc = \"dotfiles/platforms/{plat}/bashrc\"\n\
          \n\
-         [dotfiles.machines.{machine}]\n\
+         [dotfiles.machines.\"{machine}\"]\n\
          bashrc = \"dotfiles/machines/{machine}/bashrc\"\n",
     );
     fs::write(w.dir.path().join("nostos.toml"), config).unwrap();

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -314,3 +314,125 @@ fn workflow_nested_directory_creation() {
         "[window]\npadding = { x = 5, y = 5 }"
     );
 }
+
+// ── Workflow 7: Platform layering ───────────────────────
+
+/// Returns the platform key that the current OS will match.
+fn current_platform() -> &'static str {
+    if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        panic!("unsupported OS for this test")
+    }
+}
+
+#[test]
+fn workflow_platform_override_replaces_base_file() {
+    let w = Workflow::new();
+    let plat = current_platform();
+
+    // Write a config with a platform override for the current OS.
+    let target = w.dir.path().join("home").to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\n\
+         source = \"dotfiles/\"\n\
+         target = '{target}'\n\
+         \n\
+         [dotfiles.platforms.{plat}]\n\
+         bashrc = \"dotfiles/platforms/{plat}/bashrc\"\n",
+    );
+    fs::write(w.dir.path().join("nostos.toml"), config).unwrap();
+
+    // Base file
+    w.add_source("bashrc", "# base bash config");
+    // Platform-specific override
+    let platform_dir = format!("platforms/{plat}");
+    w.add_source(&format!("{platform_dir}/bashrc"), "# platform bash config");
+
+    // Plan — should show "new file" for .bashrc
+    w.nostos()
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("new file"));
+
+    // Apply — should use the platform-specific version
+    w.nostos().arg("apply").assert().success();
+    assert_eq!(w.read_target(".bashrc"), "# platform bash config");
+}
+
+#[test]
+fn workflow_platform_override_adds_new_file() {
+    let w = Workflow::new();
+    let plat = current_platform();
+
+    let target = w.dir.path().join("home").to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\n\
+         source = \"dotfiles/\"\n\
+         target = '{target}'\n\
+         \n\
+         [dotfiles.platforms.{plat}]\n\
+         platform_only = \"dotfiles/platforms/{plat}/platform_only\"\n",
+    );
+    fs::write(w.dir.path().join("nostos.toml"), config).unwrap();
+
+    // Only a base file (no platform_only in base)
+    w.add_source("bashrc", "# bash");
+    // Platform-only file
+    let platform_dir = format!("platforms/{plat}");
+    w.add_source(&format!("{platform_dir}/platform_only"), "# platform only file");
+
+    w.nostos().arg("apply").assert().success();
+
+    // Both files should exist
+    assert_eq!(w.read_target(".bashrc"), "# bash");
+    assert_eq!(w.read_target(".platform_only"), "# platform only file");
+}
+
+#[test]
+fn workflow_machine_override_wins_over_platform() {
+    let w = Workflow::new();
+    let plat = current_platform();
+    // nostos auto-detects hostname as machine_id via the `hostname` command.
+    let machine = String::from_utf8(
+        std::process::Command::new("hostname")
+            .output()
+            .expect("hostname command")
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+
+    let target = w.dir.path().join("home").to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\n\
+         source = \"dotfiles/\"\n\
+         target = '{target}'\n\
+         \n\
+         [dotfiles.platforms.{plat}]\n\
+         bashrc = \"dotfiles/platforms/{plat}/bashrc\"\n\
+         \n\
+         [dotfiles.machines.{machine}]\n\
+         bashrc = \"dotfiles/machines/{machine}/bashrc\"\n",
+    );
+    fs::write(w.dir.path().join("nostos.toml"), config).unwrap();
+
+    w.add_source("bashrc", "# base");
+    w.add_source(&format!("platforms/{plat}/bashrc"), "# platform");
+    w.add_source(&format!("machines/{machine}/bashrc"), "# machine");
+
+    // Apply — machine identity auto-detected from hostname
+    w.nostos()
+        .arg("apply")
+        .assert()
+        .success();
+
+    // Machine override wins
+    assert_eq!(w.read_target(".bashrc"), "# machine");
+}


### PR DESCRIPTION
## Summary

Implements platform/machine layering for dotfiles and files sections (closes #29).

## What changed

**New module: `src/reconcile/filemap.rs`** — deep module that resolves the
base → platform → machine cascade into a flat target → source path map.

**Config additions:**
- `[dotfiles.platforms.<os>]` and `[dotfiles.machines.<id>]` override sections
- Same for `[files.*]` sections
- Override format: `"target_path" = "repo_relative_source_path"`

**Runtime behavior:**
- Platform auto-detected from OS; machine identity from hostname
- Cascade: base → platform → machine (machine wins)
- Missing override sources and unknown platforms reported as diagnostics
- Override sources validated against repo root (path traversal / symlink rejection)
- State entries now record the repo-relative source path (`source` field)

**Updated:** reconciler signatures, CLI callers (`plan.rs`, `apply.rs`), state schema

## Testing

- 10 new unit tests in `filemap.rs` (cascade logic + security)
- 2 new state tests (backward compat + roundtrip)
- 4 new config parsing tests
- 3 new E2E workflow tests (platform replace, platform add, machine-wins)
- All 141 tests pass, clippy clean

## Docs

- README: new "Platform and machine overrides" section with config/layout examples
- `architecture.md`: module listing, config schema, MVP table updated
- `concept.md`: removed post-MVP annotations from layering
