### PR TITLE
feat: implement nostos init command

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -123,10 +123,16 @@ pub fn run(url: String, machine: Option<String>, apply: bool) -> anyhow::Result<
 }
 
 /// Default dotfiles directory: `~/.dotfiles`.
+///
+/// Checks `HOME` first (cross-platform), then falls back to `dirs::home_dir()`.
+/// This ensures tests can override the home directory on all platforms,
+/// including Windows where `dirs::home_dir()` ignores `HOME`.
 fn default_dotfiles_path() -> anyhow::Result<PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(".dotfiles"))
-        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+    Ok(home.join(".dotfiles"))
 }
 
 /// Count files in the dotfiles source directory that would be applied.

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,0 +1,172 @@
+use crate::config;
+use crate::state::{MachineInfo, State};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+pub fn run(url: String, machine: Option<String>, apply: bool) -> anyhow::Result<ExitCode> {
+    let dest = default_dotfiles_path()?;
+
+    if dest.exists() {
+        eprintln!(
+            "Target directory already exists — use `nostos sync` to update an existing repo"
+        );
+        return Ok(ExitCode::from(3));
+    }
+
+    // Clone the repository
+    println!("Cloning {url} → {}", dest.display());
+    if let Err(e) = crate::git::clone(&url, &dest) {
+        eprintln!("Error: {e}");
+        return Ok(ExitCode::from(3));
+    }
+
+    // Load or create state
+    let mut state = State::load().unwrap_or_default();
+
+    // Set machine identity
+    if let Some(ref id) = machine {
+        state.machine = Some(MachineInfo { id: id.clone() });
+    } else {
+        state.ensure_machine_identity();
+    }
+
+    // Store the repo path
+    state.set_repo_path(dest.to_string_lossy().to_string());
+
+    // Save state
+    if let Err(e) = state.save() {
+        eprintln!("Warning: failed to save state: {e}");
+    }
+
+    // Detect platform for summary
+    let platform = crate::platform::detect().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Count files that would be applied
+    let file_count = count_plannable_files(&dest);
+
+    // Print summary
+    println!();
+    println!("Repository: {}", dest.display());
+    println!("Platform:   {platform}");
+    println!(
+        "Machine:    {}",
+        state.machine_id().unwrap_or("unknown")
+    );
+    println!("Files:      {file_count} would be applied");
+
+    if apply {
+        println!();
+        println!("Applying dotfiles…");
+
+        let (config_path, cfg) = match config::find_config_with_repo(Some(&dest)) {
+            Ok(result) => result,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                return Ok(ExitCode::from(3));
+            }
+        };
+
+        let repo_root = config::repo_root_from_config(&config_path);
+        let machine_id = state.machine_id().map(|s| s.to_string());
+
+        let report = match crate::reconcile::apply(
+            &cfg,
+            &mut state,
+            &repo_root,
+            &platform,
+            machine_id.as_deref(),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                return Ok(ExitCode::from(3));
+            }
+        };
+
+        if let Some(ref dotfiles_report) = report.dotfiles {
+            for action in &dotfiles_report.actions {
+                match action {
+                    crate::reconcile::dotfiles::DotfileAction::NewFile { target, .. } => {
+                        println!("  ✓ Copied → {}", target.display());
+                    }
+                    crate::reconcile::dotfiles::DotfileAction::UpToDate { target } => {
+                        println!(
+                            "  ✓ {} — up to date",
+                            target
+                                .file_name()
+                                .map(|f| f.to_string_lossy().to_string())
+                                .unwrap_or_else(|| target.display().to_string())
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            for err in &dotfiles_report.errors {
+                eprintln!("  ✗ {err}");
+            }
+        }
+
+        // Save state again after apply
+        if let Err(e) = state.save() {
+            eprintln!("Warning: failed to save state: {e}");
+        }
+
+        if report.has_warnings() || report.has_errors() {
+            return Ok(ExitCode::from(5));
+        }
+    } else {
+        println!();
+        println!("Run `nostos plan` to preview changes, then `nostos apply` to apply them.");
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Default dotfiles directory: `~/.dotfiles`.
+fn default_dotfiles_path() -> anyhow::Result<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".dotfiles"))
+        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))
+}
+
+/// Count files in the dotfiles source directory that would be applied.
+fn count_plannable_files(repo_root: &std::path::Path) -> usize {
+    let config_path = repo_root.join("nostos.toml");
+    let cfg = match config::load(&config_path) {
+        Ok(c) => c,
+        Err(_) => return 0,
+    };
+
+    let mut count = 0;
+
+    if let Some(ref df) = cfg.dotfiles {
+        let source_dir = repo_root.join(&df.source);
+        if source_dir.is_dir() {
+            count += count_files_recursive(&source_dir);
+        }
+    }
+
+    if let Some(ref files) = cfg.files {
+        let source_dir = repo_root.join(&files.source);
+        if source_dir.is_dir() {
+            count += count_files_recursive(&source_dir);
+        }
+    }
+
+    count
+}
+
+fn count_files_recursive(dir: &std::path::Path) -> usize {
+    let mut count = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                count += 1;
+            } else if path.is_dir() {
+                count += count_files_recursive(&path);
+            }
+        }
+    }
+    count
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 mod apply;
+mod init;
 mod plan;
 mod status;
 
@@ -20,6 +21,17 @@ pub struct Cli {
 /// A top-level subcommand.
 #[derive(Subcommand)]
 pub enum Command {
+    /// Clone a dotfiles repo and set up this machine
+    Init {
+        /// Git URL of the dotfiles repository to clone
+        url: String,
+        /// Machine identity (defaults to hostname)
+        #[arg(long)]
+        machine: Option<String>,
+        /// Apply dotfiles after cloning
+        #[arg(long)]
+        apply: bool,
+    },
     /// Show platform info and config validity
     Status,
     /// Dry-run: show what apply would do
@@ -32,6 +44,7 @@ pub enum Command {
 pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
     let repo = cli.repo.as_deref();
     match cli.command {
+        Command::Init { url, machine, apply } => init::run(url, machine, apply),
         Command::Status => status::run(repo),
         Command::Plan => plan::run(repo),
         Command::Apply => apply::run(repo),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -270,10 +270,10 @@ fn init_with_apply_copies_files() {
         .stdout(predicate::str::contains("Applying"))
         .stdout(predicate::str::contains("Copied"));
 
-    assert_eq!(
-        fs::read_to_string(fake_home.join(".bashrc")).unwrap(),
-        "# from init --apply\n"
-    );
+    let content = fs::read_to_string(fake_home.join(".bashrc")).unwrap();
+    // Normalise line endings — git on Windows may convert \n → \r\n
+    let content = content.replace("\r\n", "\n");
+    assert_eq!(content, "# from init --apply\n");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -67,6 +67,236 @@ impl TestFixture {
     }
 }
 
+/// Helper to create a bare git repo to use as a fake "remote" for init tests.
+fn create_bare_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    let bare = dir.join("remote.git");
+    std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare)
+        .output()
+        .expect("git init --bare");
+
+    // Create a non-bare clone, add a nostos.toml + dotfiles, push
+    let work = dir.join("work");
+    std::process::Command::new("git")
+        .args(["clone"])
+        .arg(&bare)
+        .arg(&work)
+        .output()
+        .expect("git clone");
+
+    fs::create_dir_all(work.join("dotfiles")).unwrap();
+    fs::write(work.join("dotfiles/bashrc"), "# bash config\n").unwrap();
+
+    // nostos.toml — use a placeholder target; init tests that apply will
+    // override HOME so the target resolves under the temp tree.
+    fs::write(
+        work.join("nostos.toml"),
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = \"~/\"\n",
+    )
+    .unwrap();
+
+    // git add + commit + push
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&work)
+        .output()
+        .expect("git add");
+    std::process::Command::new("git")
+        .args([
+            "-c", "user.name=test",
+            "-c", "user.email=test@test.com",
+            "commit", "-m", "initial",
+        ])
+        .current_dir(&work)
+        .output()
+        .expect("git commit");
+    std::process::Command::new("git")
+        .args(["push"])
+        .current_dir(&work)
+        .output()
+        .expect("git push");
+
+    bare
+}
+
+// ── Init tests ───────────────────────────────────────────
+
+#[test]
+fn init_clones_repo_and_sets_state() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Repository:"))
+        .stdout(predicate::str::contains("Platform:"))
+        .stdout(predicate::str::contains("Machine:"));
+
+    // .dotfiles should exist under fake home
+    assert!(fake_home.join(".dotfiles").exists());
+
+    // State file should contain repo path and machine identity
+    let state_path = fake_home.join("xdg-config/nostos/state.toml");
+    let state_content = fs::read_to_string(&state_path).unwrap();
+    assert!(state_content.contains(".dotfiles"));
+    assert!(state_content.contains("[machine]"));
+}
+
+#[test]
+fn init_with_machine_flag() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .arg("--machine")
+        .arg("work-laptop")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Machine:    work-laptop"));
+
+    let state_path = fake_home.join("xdg-config/nostos/state.toml");
+    let state_content = fs::read_to_string(&state_path).unwrap();
+    assert!(state_content.contains("work-laptop"));
+}
+
+#[test]
+fn init_target_exists_errors() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(fake_home.join(".dotfiles")).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("Target directory already exists"));
+}
+
+#[test]
+fn init_with_apply_copies_files() {
+    let dir = TempDir::new().unwrap();
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    // Create a bare repo with a nostos.toml that targets the fake home
+    let bare = dir.path().join("remote.git");
+    std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare)
+        .output()
+        .expect("git init --bare");
+
+    let work = dir.path().join("work");
+    std::process::Command::new("git")
+        .args(["clone"])
+        .arg(&bare)
+        .arg(&work)
+        .output()
+        .expect("git clone");
+
+    fs::create_dir_all(work.join("dotfiles")).unwrap();
+    fs::write(work.join("dotfiles/bashrc"), "# from init --apply\n").unwrap();
+
+    // Use absolute target path so apply works predictably
+    let target = fake_home.to_string_lossy().to_string();
+    fs::write(
+        work.join("nostos.toml"),
+        format!("[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n"),
+    )
+    .unwrap();
+
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&work)
+        .output()
+        .expect("git add");
+    std::process::Command::new("git")
+        .args([
+            "-c", "user.name=test",
+            "-c", "user.email=test@test.com",
+            "commit", "-m", "initial",
+        ])
+        .current_dir(&work)
+        .output()
+        .expect("git commit");
+    std::process::Command::new("git")
+        .args(["push"])
+        .current_dir(&work)
+        .output()
+        .expect("git push");
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applying"))
+        .stdout(predicate::str::contains("Copied"));
+
+    assert_eq!(
+        fs::read_to_string(fake_home.join(".bashrc")).unwrap(),
+        "# from init --apply\n"
+    );
+}
+
+#[test]
+fn init_suggests_plan_without_apply() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("nostos plan"));
+}
+
 // ── Status tests ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Add `nostos init <url>` to clone a dotfiles repo and set machine identity. Supports `--machine` for explicit identity and `--apply` for immediate application after cloning.

Closes #31.