### PR TITLE
feat: implement nostos track command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod apply;
 mod plan;
 mod status;
+mod track;
 
 use clap::{Parser, Subcommand};
 use std::process::ExitCode;
@@ -26,6 +27,11 @@ pub enum Command {
     Plan,
     /// Apply dotfiles from the repo to this machine
     Apply,
+    /// Track a target file back into the repo
+    Track {
+        /// Path to the target file to track back into the repo
+        path: std::path::PathBuf,
+    },
 }
 
 /// Run the CLI. Returns an ExitCode.
@@ -35,5 +41,6 @@ pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         Command::Status => status::run(repo),
         Command::Plan => plan::run(repo),
         Command::Apply => apply::run(repo),
+        Command::Track { path } => track::run(repo, path),
     }
 }

--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -1,0 +1,218 @@
+use crate::config;
+use crate::reconcile::dotfiles::{expand_tilde, hash_file};
+use crate::state::State;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+pub fn run(repo: Option<&Path>, path: PathBuf) -> anyhow::Result<ExitCode> {
+    let state = State::load().unwrap_or_default();
+
+    // Resolve repo root: explicit flag > state > cwd (if nostos.toml exists)
+    let repo_root = if let Some(r) = repo {
+        r.to_path_buf()
+    } else if let Some(p) = state.repo_path() {
+        PathBuf::from(p)
+    } else {
+        let cwd = std::env::current_dir()
+            .map_err(|e| anyhow::anyhow!("cannot determine current directory: {e}"))?;
+        if cwd.join("nostos.toml").exists() {
+            cwd
+        } else {
+            eprintln!("No repo path configured — run `nostos init` first");
+            return Ok(ExitCode::from(3));
+        }
+    };
+
+    let (_, cfg) = match config::find_config_with_repo(Some(&repo_root)) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("{e}");
+            return Ok(ExitCode::from(3));
+        }
+    };
+
+    // Canonicalize the target path
+    let target_path = if path.is_absolute() {
+        path.clone()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| anyhow::anyhow!("cannot determine current directory: {e}"))?
+            .join(&path)
+    };
+    let target_path = target_path.canonicalize().map_err(|e| {
+        anyhow::anyhow!("cannot resolve path {}: {e}", path.display())
+    })?;
+
+    // Try to find the file in state (managed file case)
+    if let Some(result) = try_track_managed(&target_path, &cfg, &state, &repo_root)? {
+        return Ok(result);
+    }
+
+    // New file case — use dot heuristic
+    track_new_file(&target_path, &cfg, &repo_root)
+}
+
+/// Attempt to track a managed file (one that exists in state.applied).
+/// Returns `Some(ExitCode)` if we handled it, `None` if the file is not managed.
+fn try_track_managed(
+    target_path: &Path,
+    cfg: &config::Config,
+    state: &State,
+    repo_root: &Path,
+) -> anyhow::Result<Option<ExitCode>> {
+    // Try matching against dotfiles target dir
+    if let Some(ref df) = cfg.dotfiles {
+        let target_base = expand_tilde(&df.target)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if let Ok(rel) = target_path.strip_prefix(&target_base) {
+            let key = rel.to_string_lossy().replace('\\', "/");
+            if let Some(entry) = state.applied.get(&key) {
+                return do_track_managed(target_path, entry, &key, &df.source, repo_root, state)
+                    .map(Some);
+            }
+        }
+    }
+
+    // Try matching against files target dir
+    if let Some(ref files) = cfg.files {
+        let target_base = expand_tilde(&files.target)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if let Ok(rel) = target_path.strip_prefix(&target_base) {
+            let key = rel.to_string_lossy().replace('\\', "/");
+            if let Some(entry) = state.applied.get(&key) {
+                return do_track_managed(target_path, entry, &key, &files.source, repo_root, state)
+                    .map(Some);
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Execute the tracking of a managed file: copy target → source, update state.
+fn do_track_managed(
+    target_path: &Path,
+    entry: &crate::state::AppliedEntry,
+    key: &str,
+    default_source_dir: &str,
+    repo_root: &Path,
+    state: &State,
+) -> anyhow::Result<ExitCode> {
+    // Determine source path from state or derive from convention
+    let source_path = if let Some(ref source_rel) = entry.source {
+        repo_root.join(source_rel)
+    } else {
+        let filename = key.strip_prefix('.').unwrap_or(key);
+        repo_root.join(default_source_dir).join(filename)
+    };
+
+    if let Some(parent) = source_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
+    }
+    std::fs::copy(target_path, &source_path)
+        .map_err(|e| anyhow::anyhow!("cannot copy {} → {}: {e}", target_path.display(), source_path.display()))?;
+
+    let new_hash = hash_file(target_path)
+        .map_err(|e| anyhow::anyhow!("cannot hash {}: {e}", target_path.display()))?;
+
+    let mut state = state.clone();
+    if let Some(applied) = state.applied.get_mut(key) {
+        applied.hash = new_hash;
+        applied.timestamp = chrono::Utc::now();
+    }
+
+    if let Err(e) = state.save() {
+        eprintln!("Warning: failed to save state: {e}");
+    }
+
+    println!(
+        "Tracked {} → {}",
+        target_path.display(),
+        source_path.display()
+    );
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Track a new (unmanaged) file into the repo.
+fn track_new_file(
+    target_path: &Path,
+    cfg: &config::Config,
+    repo_root: &Path,
+) -> anyhow::Result<ExitCode> {
+    let filename = target_path
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let is_dotfile = filename.starts_with('.');
+
+    if is_dotfile {
+        let df = match cfg.dotfiles {
+            Some(ref df) => df,
+            None => {
+                eprintln!(
+                    "Cannot track {}: no [dotfiles] section configured",
+                    target_path.display()
+                );
+                return Ok(ExitCode::from(3));
+            }
+        };
+
+        let stripped = filename.strip_prefix('.').unwrap_or(&filename);
+        let dest = repo_root.join(&df.source).join(stripped);
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
+        }
+        std::fs::copy(target_path, &dest)
+            .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
+
+        let rel_dest = dest
+            .strip_prefix(repo_root)
+            .unwrap_or(&dest)
+            .display();
+        println!("Copied {} → {}", target_path.display(), dest.display());
+        println!();
+        println!("Add to nostos.toml (file is not yet managed until you do):");
+        println!("  # The base source directory already covers this file.");
+        println!("  # If you need a platform/machine override, add:");
+        println!("  # [dotfiles.platforms.<os>]");
+        println!("  # \"{stripped}\" = \"{rel_dest}\"");
+    } else {
+        let files = match cfg.files {
+            Some(ref f) => f,
+            None => {
+                eprintln!(
+                    "Cannot track {}: no [files] section configured",
+                    target_path.display()
+                );
+                return Ok(ExitCode::from(3));
+            }
+        };
+
+        let dest = repo_root.join(&files.source).join(&filename);
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
+        }
+        std::fs::copy(target_path, &dest)
+            .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
+
+        let rel_dest = dest
+            .strip_prefix(repo_root)
+            .unwrap_or(&dest)
+            .display();
+        println!("Copied {} → {}", target_path.display(), dest.display());
+        println!();
+        println!("Add to nostos.toml (file is not yet managed until you do):");
+        println!("  # The base source directory already covers this file.");
+        println!("  # If you need a platform/machine override, add:");
+        println!("  # [files.platforms.<os>]");
+        println!("  # \"{filename}\" = \"{rel_dest}\"");
+    }
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -64,6 +64,8 @@ fn try_track_managed(
     if let Some(ref df) = cfg.dotfiles {
         let target_base = expand_tilde(&df.target)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Canonicalize to handle symlinks (e.g. /var → /private/var on macOS)
+        let target_base = target_base.canonicalize().unwrap_or(target_base);
         if let Ok(rel) = target_path.strip_prefix(&target_base) {
             let key = rel.to_string_lossy().replace('\\', "/");
             if let Some(entry) = state.applied.get(&key) {
@@ -77,6 +79,7 @@ fn try_track_managed(
     if let Some(ref files) = cfg.files {
         let target_base = expand_tilde(&files.target)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let target_base = target_base.canonicalize().unwrap_or(target_base);
         if let Ok(rel) = target_path.strip_prefix(&target_base) {
             let key = rel.to_string_lossy().replace('\\', "/");
             if let Some(entry) = state.applied.get(&key) {

--- a/src/reconcile/dotfiles.rs
+++ b/src/reconcile/dotfiles.rs
@@ -500,7 +500,7 @@ fn dot_prepend(rel_path: &str) -> String {
 }
 
 /// Expand `~` to the user's home directory.
-fn expand_tilde(path: &str) -> Result<PathBuf, Error> {
+pub(crate) fn expand_tilde(path: &str) -> Result<PathBuf, Error> {
     if path == "~" || path.starts_with("~/") {
         let home = dirs::home_dir().ok_or(Error::NoHomeDir)?;
         if path == "~" {
@@ -517,7 +517,7 @@ fn expand_tilde(path: &str) -> Result<PathBuf, Error> {
 ///
 /// Streams the file through the hasher with a fixed-size buffer so that large
 /// files do not cause RSS to grow proportionally to file size.
-fn hash_file(path: &Path) -> Result<String, std::io::Error> {
+pub(crate) fn hash_file(path: &Path) -> Result<String, std::io::Error> {
     use std::io::Read;
     let mut file = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -411,3 +411,172 @@ bin = "rg"
         .success()
         .stdout(predicate::str::contains("tool(s) declared"));
 }
+
+// ── Track tests ──────────────────────────────────────────
+
+#[test]
+fn track_managed_file_updates_source_and_state() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original");
+
+    // Apply first to create state
+    fix.nostos().arg("apply").assert().success();
+    assert_eq!(fix.read_target(".bashrc"), "# original");
+
+    // Edit the target file
+    fix.add_target(".bashrc", "# user edited version");
+
+    // Track it back
+    let target_path = fix.target_dir().join(".bashrc");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked"));
+
+    // Verify the source was updated
+    let source_content =
+        fs::read_to_string(fix.dir.path().join("dotfiles").join("bashrc")).unwrap();
+    assert_eq!(source_content, "# user edited version");
+
+    // Verify a subsequent apply sees no changes
+    fix.nostos()
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date"));
+}
+
+#[test]
+fn track_new_dotfile_copies_without_dot() {
+    let fix = TestFixture::new().with_default_config();
+
+    // Create a dotfile in the target directory (not yet managed)
+    fix.add_target(".newrc", "# brand new dotfile");
+
+    let target_path = fix.target_dir().join(".newrc");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    // Verify file went to dotfiles source dir without the dot prefix
+    let source_path = fix.dir.path().join("dotfiles").join("newrc");
+    assert!(source_path.exists(), "source file should exist without dot");
+    assert_eq!(fs::read_to_string(&source_path).unwrap(), "# brand new dotfile");
+}
+
+#[test]
+fn track_new_plain_file_copies_to_files_dir() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n\n[files]\nsource = \"files/\"\ntarget = '{target}'\n"
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files")).unwrap();
+
+    // Create a non-dot file in the target directory
+    fix.add_target("myscript", "#!/bin/sh\necho hello");
+
+    let target_path = fix.target_dir().join("myscript");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    // Verify file went to files source dir with the same name
+    let source_path = fix.dir.path().join("files").join("myscript");
+    assert!(source_path.exists(), "source file should exist in files dir");
+    assert_eq!(
+        fs::read_to_string(&source_path).unwrap(),
+        "#!/bin/sh\necho hello"
+    );
+}
+
+#[test]
+fn track_no_dotfiles_section_errors() {
+    let fix = TestFixture::new();
+    // Config with only [files], no [dotfiles]
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!("[files]\nsource = \"files/\"\ntarget = '{target}'\n");
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files")).unwrap();
+
+    // Try to track a dotfile — should fail
+    fix.add_target(".myrc", "# content");
+    let target_path = fix.target_dir().join(".myrc");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("no [dotfiles] section configured"));
+}
+
+#[test]
+fn track_no_files_section_errors() {
+    let fix = TestFixture::new().with_default_config();
+
+    // Try to track a non-dot file with no [files] section — should fail
+    fix.add_target("plainfile", "content");
+    let target_path = fix.target_dir().join("plainfile");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("no [files] section configured"));
+}
+
+#[test]
+fn track_managed_file_with_layered_source() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        r#"[dotfiles]
+source = "dotfiles/"
+target = '{target}'
+
+[dotfiles.platforms.linux]
+"bashrc" = "dotfiles/platforms/linux/bashrc"
+"#
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+
+    // Create both base and platform-override source files
+    fix.add_source("bashrc", "# base bashrc");
+    let platform_dir = fix.dir.path().join("dotfiles/platforms/linux");
+    fs::create_dir_all(&platform_dir).unwrap();
+    fs::write(platform_dir.join("bashrc"), "# linux bashrc").unwrap();
+
+    // Apply — on Linux this should use the platform override
+    fix.nostos().arg("apply").assert().success();
+    assert_eq!(fix.read_target(".bashrc"), "# linux bashrc");
+
+    // Edit target
+    fix.add_target(".bashrc", "# linux edited");
+
+    // Track it back — should go to the platform source, not base
+    let target_path = fix.target_dir().join(".bashrc");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked"));
+
+    // Verify the platform source was updated (not the base)
+    let platform_content = fs::read_to_string(platform_dir.join("bashrc")).unwrap();
+    assert_eq!(platform_content, "# linux edited");
+
+    // Base should be untouched
+    let base_content =
+        fs::read_to_string(fix.dir.path().join("dotfiles").join("bashrc")).unwrap();
+    assert_eq!(base_content, "# base bashrc");
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -538,29 +538,39 @@ fn track_no_files_section_errors() {
 fn track_managed_file_with_layered_source() {
     let fix = TestFixture::new();
     let target = fix.target_dir().to_string_lossy().to_string();
+
+    // Use the current platform so the override applies on any OS
+    let platform = if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "windows"
+    };
+
     let config = format!(
         r#"[dotfiles]
 source = "dotfiles/"
 target = '{target}'
 
-[dotfiles.platforms.linux]
-"bashrc" = "dotfiles/platforms/linux/bashrc"
+[dotfiles.platforms.{platform}]
+"bashrc" = "dotfiles/platforms/{platform}/bashrc"
 "#
     );
     fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
 
     // Create both base and platform-override source files
     fix.add_source("bashrc", "# base bashrc");
-    let platform_dir = fix.dir.path().join("dotfiles/platforms/linux");
+    let platform_dir = fix.dir.path().join(format!("dotfiles/platforms/{platform}"));
     fs::create_dir_all(&platform_dir).unwrap();
-    fs::write(platform_dir.join("bashrc"), "# linux bashrc").unwrap();
+    fs::write(platform_dir.join("bashrc"), "# platform bashrc").unwrap();
 
-    // Apply — on Linux this should use the platform override
+    // Apply — should use the platform override
     fix.nostos().arg("apply").assert().success();
-    assert_eq!(fix.read_target(".bashrc"), "# linux bashrc");
+    assert_eq!(fix.read_target(".bashrc"), "# platform bashrc");
 
     // Edit target
-    fix.add_target(".bashrc", "# linux edited");
+    fix.add_target(".bashrc", "# platform edited");
 
     // Track it back — should go to the platform source, not base
     let target_path = fix.target_dir().join(".bashrc");
@@ -573,7 +583,7 @@ target = '{target}'
 
     // Verify the platform source was updated (not the base)
     let platform_content = fs::read_to_string(platform_dir.join("bashrc")).unwrap();
-    assert_eq!(platform_content, "# linux edited");
+    assert_eq!(platform_content, "# platform edited");
 
     // Base should be untouched
     let base_content =


### PR DESCRIPTION
## Summary

Add `nostos track <path>` to reverse-sync a target file back into the dotfiles repo. Handles both managed files (using state source field for correct placement) and new files (using dot-prefix heuristic). Does not auto-commit.

Closes #33.