### PR TITLE
feat: implement nostos sync command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod apply;
 mod init;
 mod plan;
 mod status;
+mod sync;
 mod track;
 
 use clap::{Parser, Subcommand};
@@ -44,6 +45,12 @@ pub enum Command {
         /// Path to the target file to track back into the repo
         path: std::path::PathBuf,
     },
+    /// Sync the local dotfiles repo with the remote
+    Sync {
+        /// Apply dotfiles after pulling
+        #[arg(long)]
+        apply: bool,
+    },
 }
 
 /// Run the CLI. Returns an ExitCode.
@@ -55,5 +62,6 @@ pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         Command::Plan => plan::run(repo),
         Command::Apply => apply::run(repo),
         Command::Track { path } => track::run(repo, path),
+        Command::Sync { apply } => sync::run(repo, apply),
     }
 }

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,0 +1,168 @@
+use crate::config;
+use crate::git;
+use crate::reconcile::{self, dotfiles::DotfileAction};
+use crate::state::State;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+pub fn run(repo: Option<&Path>, apply: bool) -> anyhow::Result<ExitCode> {
+    let repo_path = resolve_repo_path(repo)?;
+
+    // Step 1 — Auto-commit local changes
+    let mut state = State::load().unwrap_or_default();
+    state.ensure_machine_identity();
+    let machine_id = state.machine_id().unwrap_or("unknown");
+
+    match git::commit(&repo_path, &format!("nostos: auto-sync from {machine_id}")) {
+        Ok(git::CommitOutcome::Committed) => {
+            println!("Committed local changes");
+        }
+        Ok(git::CommitOutcome::NothingToCommit) => {}
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return Ok(ExitCode::FAILURE);
+        }
+    }
+
+    // Step 2 — Pull
+    if let Err(e) = git::pull(&repo_path) {
+        eprintln!("Error: {e}");
+        return Ok(ExitCode::FAILURE);
+    }
+    println!("Pulled from remote");
+
+    // Step 3 — Push
+    if let Err(e) = git::push(&repo_path) {
+        eprintln!("Error: {e}");
+        return Ok(ExitCode::FAILURE);
+    }
+    println!("Pushed to remote");
+
+    // Step 4 — Optional apply
+    if apply {
+        run_apply(&repo_path, &mut state)?;
+    } else {
+        println!("Run `nostos plan` to see what changed, then `nostos apply`");
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn resolve_repo_path(explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+    if let Some(p) = explicit {
+        return Ok(p.to_path_buf());
+    }
+
+    let state = State::load().unwrap_or_default();
+    if let Some(p) = state.repo_path() {
+        return Ok(PathBuf::from(p));
+    }
+
+    anyhow::bail!("No repo path configured — run `nostos init` first");
+}
+
+fn run_apply(repo_path: &Path, state: &mut State) -> anyhow::Result<()> {
+    let config_path = repo_path.join("nostos.toml");
+    let cfg = match config::load(&config_path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return Ok(());
+        }
+    };
+
+    let platform = crate::platform::detect().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let machine_id = state.machine_id().map(|s| s.to_string());
+
+    let report = match reconcile::apply(&cfg, state, repo_path, &platform, machine_id.as_deref())
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return Ok(());
+        }
+    };
+
+    if let Some(ref dotfiles_report) = report.dotfiles {
+        println!("Dotfiles:");
+        for action in &dotfiles_report.actions {
+            match action {
+                DotfileAction::NewFile { target, .. } => {
+                    println!("  ✓ Copied → {}", target.display());
+                }
+                DotfileAction::UpToDate { target } => {
+                    println!("  ✓ {} — up to date", display_target(target));
+                }
+                DotfileAction::CleanUpdate { target, .. } => {
+                    println!("  ✓ Updated → {}", target.display());
+                }
+                DotfileAction::LocalModification { target } => {
+                    println!(
+                        "  ⚠ {} — local modification, skipped",
+                        display_target(target)
+                    );
+                }
+                DotfileAction::Conflict { target, backup, .. } => {
+                    println!(
+                        "  ⚠ Backed up {} → {}",
+                        display_target(target),
+                        backup.display()
+                    );
+                    println!("  ✓ Updated → {}", target.display());
+                }
+            }
+        }
+        for err in &dotfiles_report.errors {
+            eprintln!("  ✗ {err}");
+        }
+    }
+
+    if let Some(ref files_report) = report.files {
+        println!("Files:");
+        for action in &files_report.actions {
+            match action {
+                DotfileAction::NewFile { target, .. } => {
+                    println!("  ✓ Copied → {}", target.display());
+                }
+                DotfileAction::UpToDate { target } => {
+                    println!("  ✓ {} — up to date", display_target(target));
+                }
+                DotfileAction::CleanUpdate { target, .. } => {
+                    println!("  ✓ Updated → {}", target.display());
+                }
+                DotfileAction::LocalModification { target } => {
+                    println!(
+                        "  ⚠ {} — local modification, skipped",
+                        display_target(target)
+                    );
+                }
+                DotfileAction::Conflict { target, backup, .. } => {
+                    println!(
+                        "  ⚠ Backed up {} → {}",
+                        display_target(target),
+                        backup.display()
+                    );
+                    println!("  ✓ Updated → {}", target.display());
+                }
+            }
+        }
+        for err in &files_report.errors {
+            eprintln!("  ✗ {err}");
+        }
+    }
+
+    if state.repo_path().is_none() {
+        state.set_repo_path(repo_path.to_string_lossy().to_string());
+    }
+    if let Err(e) = state.save() {
+        eprintln!("Warning: failed to save state: {e}");
+    }
+
+    Ok(())
+}
+
+fn display_target(path: &Path) -> String {
+    path.file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -729,6 +729,89 @@ fn track_new_plain_file_copies_to_files_dir() {
     );
 }
 
+// ── Sync tests ───────────────────────────────────────────
+
+/// A pair of git repos for testing sync: a bare "remote" and a local clone.
+struct SyncFixture {
+    root: TempDir,
+}
+
+impl SyncFixture {
+    fn new() -> Self {
+        let root = TempDir::new().unwrap();
+        let remote = root.path().join("remote.git");
+        let local = root.path().join("local");
+        let home = root.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+
+        // Initialise a bare remote
+        run_git(root.path(), &["init", "--bare", remote.to_str().unwrap()]);
+
+        // Clone it to "local"
+        run_git(
+            root.path(),
+            &["clone", remote.to_str().unwrap(), local.to_str().unwrap()],
+        );
+
+        // Configure user identity for the local repo
+        run_git(&local, &["config", "user.email", "test@example.com"]);
+        run_git(&local, &["config", "user.name", "Test"]);
+
+        // Seed with nostos.toml and a dotfile
+        let target = home.to_string_lossy().to_string();
+        let config = format!(
+            "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n"
+        );
+        fs::write(local.join("nostos.toml"), config).unwrap();
+        fs::create_dir_all(local.join("dotfiles")).unwrap();
+        fs::write(local.join("dotfiles").join("bashrc"), "# initial").unwrap();
+
+        run_git(&local, &["add", "--all"]);
+        run_git(&local, &["commit", "-m", "initial seed"]);
+        run_git(&local, &["push"]);
+
+        SyncFixture { root }
+    }
+
+    fn local_path(&self) -> std::path::PathBuf {
+        self.root.path().join("local")
+    }
+
+    fn remote_path(&self) -> std::path::PathBuf {
+        self.root.path().join("remote.git")
+    }
+
+    fn home_path(&self) -> std::path::PathBuf {
+        self.root.path().join("home")
+    }
+
+    fn nostos_sync(&self) -> Command {
+        let mut cmd = Command::cargo_bin("nostos").unwrap();
+        cmd.arg("--repo").arg(self.local_path());
+        cmd.arg("sync");
+        cmd.env(
+            "XDG_CONFIG_HOME",
+            self.root.path().join("xdg-config").to_str().unwrap(),
+        );
+        cmd
+    }
+}
+
+fn run_git(cwd: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git should be available");
+    assert!(
+        out.status.success(),
+        "git {:?} in {} failed: {}",
+        args,
+        cwd.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 #[test]
 fn track_no_dotfiles_section_errors() {
     let fix = TestFixture::new();
@@ -819,4 +902,97 @@ target = '{target}'
     let base_content =
         fs::read_to_string(fix.dir.path().join("dotfiles").join("bashrc")).unwrap();
     assert_eq!(base_content, "# base bashrc");
+}
+
+#[test]
+fn sync_dirty_working_tree_auto_commits() {
+    let fix = SyncFixture::new();
+
+    // Make a local change
+    fs::write(
+        fix.local_path().join("dotfiles").join("vimrc"),
+        "# new file",
+    )
+    .unwrap();
+
+    fix.nostos_sync()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Committed local changes"))
+        .stdout(predicate::str::contains("Pushed to remote"));
+}
+
+#[test]
+fn sync_clean_working_tree_skips_commit() {
+    let fix = SyncFixture::new();
+
+    fix.nostos_sync()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Committed local changes").not())
+        .stdout(predicate::str::contains("Pulled from remote"))
+        .stdout(predicate::str::contains("Pushed to remote"));
+}
+
+#[test]
+fn sync_with_apply_flag() {
+    let fix = SyncFixture::new();
+
+    fix.nostos_sync()
+        .arg("--apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dotfiles:"));
+
+    assert!(fix.home_path().join(".bashrc").exists());
+}
+
+#[test]
+fn sync_no_repo_path_errors() {
+    let dir = TempDir::new().unwrap();
+
+    let mut cmd = Command::cargo_bin("nostos").unwrap();
+    cmd.env(
+        "XDG_CONFIG_HOME",
+        dir.path().join("xdg-config").to_str().unwrap(),
+    );
+    cmd.arg("sync")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No repo path configured"));
+}
+
+#[test]
+fn sync_pulls_remote_commits() {
+    let fix = SyncFixture::new();
+
+    // Simulate a remote change via a second clone
+    let second = fix.root.path().join("second");
+    run_git(
+        fix.root.path(),
+        &[
+            "clone",
+            fix.remote_path().to_str().unwrap(),
+            second.to_str().unwrap(),
+        ],
+    );
+    run_git(&second, &["config", "user.email", "test@example.com"]);
+    run_git(&second, &["config", "user.name", "Test"]);
+    fs::write(
+        second.join("dotfiles").join("gitconfig"),
+        "# from remote",
+    )
+    .unwrap();
+    run_git(&second, &["add", "--all"]);
+    run_git(&second, &["commit", "-m", "remote commit"]);
+    run_git(&second, &["push"]);
+
+    // Sync from the local clone — should pull the remote commit
+    fix.nostos_sync()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pulled from remote"));
+
+    assert!(fix.local_path().join("dotfiles").join("gitconfig").exists());
 }


### PR DESCRIPTION
## Summary

Add `nostos sync` to synchronize the local dotfiles repo with the remote. Runs auto-commit, pull --rebase, push in sequence. Supports `--apply` to apply changes after pulling.

Closes #32.