### PR TITLE
feat: enhance nostos status with active layer display

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -6,41 +6,56 @@ use std::process::ExitCode;
 
 pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     // Platform detection
-    match platform::detect() {
+    let platform = match platform::detect() {
         Ok(platform) => {
             println!("Platform:  {platform}");
             if !platform.managers.is_empty() {
                 let names: Vec<_> = platform.managers.iter().map(|m| m.name.as_str()).collect();
                 println!("Managers:  {}", names.join(", "));
             }
+            Some(platform)
         }
         Err(e) => {
             eprintln!("Platform:  {e}");
             return Ok(ExitCode::from(4));
         }
-    }
+    };
 
     // State info (machine identity and repo path)
     let state = State::load().unwrap_or_default();
-    if let Some(id) = state.machine_id() {
+    let machine_id = state.machine_id().map(|s| s.to_string());
+    if let Some(ref id) = machine_id {
         println!("Machine:   {id}");
+    } else {
+        println!("Machine:   (not set)");
     }
     if let Some(path) = state.repo_path() {
         println!("Repo:      {path}");
+    } else {
+        println!("Repo:      (not set — run `nostos init`)");
     }
 
-    // Config validity
+    // Config validity and active layers
     match config::find_config_with_repo(repo) {
         Ok((_path, config)) => {
             println!("Config:    nostos.toml (valid)");
             if let Some(df) = &config.dotfiles {
                 println!("Dotfiles:  source={}, target={}", df.source, df.target);
             }
+            if let Some(files) = &config.files {
+                println!("Files:     source={}, target={}", files.source, files.target);
+            }
             if !config.tools.is_empty() {
                 println!("Tools:     {} declared (not yet active)", config.tools.len());
             }
             if !config.hooks.is_empty() {
                 println!("Hooks:     {} declared (not yet active)", config.hooks.len());
+            }
+
+            // Active layers
+            if let Some(ref platform) = platform {
+                let os_name = platform.os.to_string();
+                print_active_layers(&config, &os_name, machine_id.as_deref());
             }
         }
         Err(config::Error::NotFound { .. }) => {
@@ -53,4 +68,38 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
     }
 
     Ok(ExitCode::SUCCESS)
+}
+
+fn print_active_layers(config: &config::Config, os_name: &str, machine_id: Option<&str>) {
+    let mut layers = vec!["base".to_string()];
+
+    let has_platform_dotfiles = config
+        .dotfiles
+        .as_ref()
+        .is_some_and(|df| df.platforms.get(os_name).is_some_and(|m| !m.is_empty()));
+    let has_platform_files = config
+        .files
+        .as_ref()
+        .is_some_and(|f| f.platforms.get(os_name).is_some_and(|m| !m.is_empty()));
+
+    if has_platform_dotfiles || has_platform_files {
+        layers.push(os_name.to_string());
+    }
+
+    if let Some(id) = machine_id {
+        let has_machine_dotfiles = config
+            .dotfiles
+            .as_ref()
+            .is_some_and(|df| df.machines.get(id).is_some_and(|m| !m.is_empty()));
+        let has_machine_files = config
+            .files
+            .as_ref()
+            .is_some_and(|f| f.machines.get(id).is_some_and(|m| !m.is_empty()));
+
+        if has_machine_dotfiles || has_machine_files {
+            layers.push(id.to_string());
+        }
+    }
+
+    println!("Layers:    {}", layers.join(" + "));
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -621,6 +621,101 @@ fn status_shows_platform_and_managers() {
 }
 
 #[test]
+fn status_shows_machine_not_set() {
+    let fix = TestFixture::new().with_default_config();
+    fix.nostos()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Machine:   (not set)"));
+}
+
+#[test]
+fn status_shows_repo_not_set() {
+    let fix = TestFixture::new().with_default_config();
+    fix.nostos()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Repo:      (not set"));
+}
+
+#[test]
+fn status_shows_base_layer() {
+    let fix = TestFixture::new().with_default_config();
+    fix.nostos()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Layers:    base"));
+}
+
+#[test]
+fn status_shows_active_platform_layer() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+
+    let platform = if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "windows"
+    };
+
+    let config = format!(
+        r#"[dotfiles]
+source = "dotfiles/"
+target = '{target}'
+
+[dotfiles.platforms.{platform}]
+"bashrc" = "dotfiles/platforms/{platform}/bashrc"
+"#
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("dotfiles")).unwrap();
+
+    fix.nostos()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!("Layers:    base + {platform}")));
+}
+
+#[test]
+fn status_empty_platform_section_not_counted_as_layer() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+
+    let platform = if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "windows"
+    };
+
+    // Platform section exists but has no entries
+    let config = format!(
+        r#"[dotfiles]
+source = "dotfiles/"
+target = '{target}'
+
+[dotfiles.platforms.{platform}]
+"#
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("dotfiles")).unwrap();
+
+    fix.nostos()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Layers:    base"))
+        .stdout(predicate::str::contains(format!("base + {platform}")).not());
+}
+
+#[test]
 fn config_only_tools_no_dotfiles_is_valid() {
     let fixture = TestFixture::new();
     let config = r#"


### PR DESCRIPTION
## Summary

Enhance `nostos status` to show additional environment context:

- **Machine identity** — always displayed (shows "not set" if init hasn't run)
- **Repo path** — always displayed (shows "not set" with guidance if missing)
- **Files section** — shown when configured (previously only dotfiles were listed)
- **Active layers** — displays which layers apply for the current environment (e.g., `base + linux + work-macbook`)

Adds 4 new CLI integration tests covering machine, repo, base layer, and platform layer display.

Closes #34.