### PR TITLE
docs: update design docs for milestone 2

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,13 +10,18 @@ The smallest useful first build. Everything else is deferred until this
 works end-to-end.
 
 **In scope for MVP:**
-- Config parser (TOML, single file, no layering yet)
+- Config parser (TOML, single file, platform/machine layering)
 - Platform detection (OS, architecture, distro)
 - Dotfiles module (copy-based placement, dot-prepend convention)
+- Files module (verbatim copy, no path transformation)
 - Conflict detection (hash-based state tracking)
-- `nostos apply` command (apply dotfiles)
+- `nostos apply` command (apply dotfiles and files)
 - `nostos plan` command (dry-run of apply)
-- `nostos status` command (show machine identity and platform info)
+- `nostos status` command (show machine identity, platform, active layers)
+- `nostos init` command (clone repo, set machine identity via git CLI)
+- `nostos sync` command (commit, pull --rebase, push via git CLI)
+- `nostos track` command (reverse-sync target files back into repo)
+- Git CLI wrapper module (see [ADR 0001](adr/0001-git-cli-over-libgit2.md))
 - Structured error handling (`thiserror` + `anyhow` + `miette` for
   config diagnostics) — wired up from the start so typed module errors
   are surfaced with context at command boundaries
@@ -26,10 +31,6 @@ works end-to-end.
   - Per-distro installer preferences
 - Hook executor
 - Platform/machine layering for hooks and tools
-- `nostos init` (git clone via libgit2)
-- `nostos sync` (commit/push/pull)
-- `nostos track` (reverse sync)
-- `[files]` section (verbatim copy)
 - Multi-repo support (`repo add`/`remove`/`list`, unified merge across
   repos, `[[repo]]` state tracking — see concept.md)
 
@@ -42,12 +43,12 @@ src/
 ├── cli/                 ← command-line interface
 │   ├── mod.rs           ← clap app definition
 │   ├── apply.rs         ← nostos apply
-│   ├── init.rs          ← nostos init (post-MVP)
+│   ├── init.rs          ← nostos init (clone repo, set machine identity)
 │   ├── plan.rs          ← nostos plan
 │   ├── repo.rs          ← nostos repo add/remove/list (post-MVP)
-│   ├── status.rs        ← nostos status
-│   ├── sync.rs          ← nostos sync (post-MVP)
-│   └── track.rs         ← nostos track (post-MVP)
+│   ├── status.rs        ← nostos status (platform, layers, managers)
+│   ├── sync.rs          ← nostos sync (commit, pull --rebase, push)
+│   └── track.rs         ← nostos track (reverse-sync target → repo)
 ├── config/              ← configuration parsing and merging
 │   ├── mod.rs           ← top-level Config struct
 │   ├── dotfiles.rs      ← dotfile config types
@@ -67,8 +68,8 @@ src/
 ├── state/               ← local machine state (state.toml)
 │   └── mod.rs           ← read/write applied hashes, machine identity,
 │                           repo registry (post-MVP: [[repo]] array)
-└── git/                 ← git operations
-    └── mod.rs           ← clone, commit, push, pull via libgit2
+└── git/                 ← git operations (CLI wrapper; see ADR 0001)
+    └── mod.rs           ← clone, commit, push, pull via git CLI
 ```
 
 ## Config schema
@@ -97,11 +98,19 @@ target = "~"                            # required, target directory
 [dotfiles.machines.<machine-id>]        # optional
 "<target-path>" = "<source-path>"
 
-# ── Files (verbatim copy, no dot-prepend) ── post-MVP ────
+# ── Files (verbatim copy, no dot-prepend) ────────────────
 
 [files]
 source = "files/"                       # required
 target = "~"                            # required
+
+# Platform-specific overrides (same format as dotfiles).
+[files.platforms.<platform>]
+"<target-path>" = "<source-path>"
+
+# Machine-specific overrides.
+[files.machines.<machine-id>]
+"<target-path>" = "<source-path>"
 
 # ── Hooks ── post-MVP ────────────────────────────────────
 
@@ -141,6 +150,7 @@ following sections drive behaviour in the first build:
 | Section | MVP behaviour |
 |---------|---------------|
 | `[dotfiles]` (source, target, platforms, machines) | Copy-based placement with dot-prepend, platform/machine override cascade |
+| `[files]` (source, target, platforms, machines) | Verbatim copy with platform/machine override cascade |
 | Everything else | Rejected with a diagnostic ("not yet supported") |
 
 ### Field types
@@ -173,9 +183,11 @@ following sections drive behaviour in the first build:
 | `thiserror` | Typed error enums per module | derive API |
 | `anyhow` | Application-level error propagation | CLI layer only — never in public library APIs |
 | `miette` | Rich diagnostics for config parse errors | `fancy` feature in the binary; config module only |
-| `git2` | Git operations via libgit2 | deferred to post-MVP |
 | `sha2` | Content hashing for conflict detection | SHA-256 |
 | `dirs` | Platform-appropriate config/data directories | state.toml location |
+
+Git operations shell out to the `git` CLI instead of using `git2`/libgit2.
+See [ADR 0001](adr/0001-git-cli-over-libgit2.md) for rationale.
 
 ## State file schema
 
@@ -185,6 +197,9 @@ concept.md) and is never synced to git.
 ```toml
 [machine]
 id = "work-macbook"                    # set at init time
+
+[repo]
+path = "/home/user/.config/nostos/dotfiles"  # absolute path to the repo clone
 
 # --- Post-MVP: multi-repo support ---
 # When multi-repo is enabled, the repo registry tracks all configured
@@ -305,3 +320,6 @@ non-zero exits from `plan`.
 - **State file** — unit tests for read/write/update of `state.toml`.
 - **CLI commands** — integration tests that run the binary and assert
   stdout/stderr output and exit codes.
+- **End-to-end workflows** — integration tests that exercise multi-step
+  scenarios (init → apply → track → sync) with temp repos and git
+  operations, covering cross-platform edge cases.

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -636,10 +636,12 @@ For now, nostos reports the git conflict and stops. The user resolves it
 manually using standard git tools (`git status`, edit the conflicted
 files, `git add`, `git commit`), then re-runs `nostos apply`.
 
-**Open question:** Should nostos try smarter strategies (auto-merge
-non-overlapping TOML changes, use `git pull --rebase` to linearize
-history)? This can be revisited once real-world conflict frequency is
-known.
+**Open question resolved:** nostos uses `git pull --rebase` to linearize
+history and avoid merge commits in personal dotfile repos. If the rebase
+encounters conflicts, nostos reports the conflict and stops — the user
+resolves manually with standard git tools, then re-runs `nostos sync`.
+See [ADR 0001](adr/0001-git-cli-over-libgit2.md) for the decision to
+use the git CLI for all git operations.
 
 ### Execution model
 
@@ -1028,7 +1030,7 @@ curl -fsSL https://github.com/benferse/nostos/releases/latest/download/nostos-ma
 chmod +x /usr/local/bin/nostos
 
 # Clone your config repo and apply everything
-# (no external git needed — nostos uses embedded libgit2)
+# (requires git on PATH — see ADR 0001)
 nostos init https://github.com/user/dotfiles.git
 
 # nostos detects: macOS, aarch64
@@ -1320,7 +1322,7 @@ ignored by git.
 │    installer preference resolution)         │
 ├─────────────────────────────────────────────┤
 │              Git Backend                    │
-│           (libgit2 via git2 crate)          │
+│           (git CLI; see ADR 0001)           │
 └─────────────────────────────────────────────┘
 ```
 
@@ -1640,18 +1642,20 @@ entries. The single-repo schema is a subset of the multi-repo schema
 ## Resolved decisions
 
 - **Bootstrap** — nostos is a single static binary distributed via GitHub
-  Releases. It embeds git support via libgit2 (`git2` crate), so no
-  external `git` command is needed. Users with Rust installed can also
-  `cargo install nostos`. The full bootstrap flow for a fresh machine is:
+  Releases. It shells out to the `git` CLI for git operations (see
+  [ADR 0001](adr/0001-git-cli-over-libgit2.md)), inheriting the user's
+  existing authentication config transparently. Users with Rust installed
+  can also `cargo install nostos`. The full bootstrap flow for a fresh
+  machine is:
 
   1. Download the nostos binary (`curl` or web browser)
-  2. `nostos init <url>` clones the config repo (via embedded libgit2)
-  3. Pre-apply hooks run (install Homebrew, etc.)
-  4. Dotfiles and tools are applied
+  2. Install `git` if not already present
+  3. `nostos init <url>` clones the config repo (via git CLI)
+  4. Pre-apply hooks run (install Homebrew, etc.)
+  5. Dotfiles and tools are applied
 
-  The only prerequisite on a fresh machine is the ability to download
-  the nostos binary. Everything else — git, package managers, tools —
-  flows from there.
+  The prerequisites on a fresh machine are the nostos binary and `git`.
+  Everything else — package managers, tools — flows from there.
 
 - **Plugin system** — nostos will not support third-party plugins or
   extensions. New package manager support or features are added directly


### PR DESCRIPTION
## Summary

Update `docs/architecture.md` and `docs/concept.md` to reflect the implemented state after milestone 2.

### architecture.md
- Move init, sync, track, files, layering, and git module from deferred to in-scope MVP
- Update module structure annotations to reflect current implementation
- Replace `git2`/libgit2 dependency with git CLI note + ADR 0001 link
- Add `[files]` platform/machine override sections to config schema
- Add `[repo]` section to state.toml schema
- Add files section to MVP-active config table
- Add E2E workflow tests to testing strategy

### concept.md
- Resolve open question on sync merge strategy (uses `git pull --rebase`)
- Update bootstrap flow to require git CLI instead of embedded libgit2
- Fix architecture diagram label and bootstrap example comment

### CONTEXT.md
- Reviewed; glossary already up-to-date with all milestone 2 terms

Closes #35.