### PR TITLE
refactor: remove duplication in CLI reporting and reconcile phases

### DIFF
--- a/src/cli/apply.rs
+++ b/src/cli/apply.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::reconcile::{self, dotfiles::DotfileAction};
+use crate::reconcile;
 use crate::state::State;
 use std::path::Path;
 use std::process::ExitCode;
@@ -28,30 +28,13 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
         }
     };
 
-    // Print dotfiles results
     if let Some(ref dotfiles_report) = report.dotfiles {
-        println!("Dotfiles:");
-        print_actions(&dotfiles_report.actions);
-        for err in &dotfiles_report.errors {
-            eprintln!("  ✗ {err}");
-        }
+        super::report::print_apply_section("Dotfiles", dotfiles_report);
     }
-
-    // Print files results
     if let Some(ref files_report) = report.files {
-        println!("Files:");
-        print_actions(&files_report.actions);
-        for err in &files_report.errors {
-            eprintln!("  ✗ {err}");
-        }
+        super::report::print_apply_section("Files", files_report);
     }
-
-    // Print pending phase warnings
-    for phase in &report.pending_phases {
-        if let Some(ref reason) = phase.skipped_reason {
-            println!("⚠ {reason}");
-        }
-    }
+    super::report::print_pending_phases(&report);
 
     // Store repo path in state if not already set
     if state.repo_path().is_none() {
@@ -68,42 +51,6 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
         Ok(ExitCode::from(5))
     } else {
         Ok(ExitCode::SUCCESS)
-    }
-}
-
-fn display_target(path: &std::path::Path) -> String {
-    path.file_name()
-        .map(|f| f.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.display().to_string())
-}
-
-fn print_actions(actions: &[DotfileAction]) {
-    for action in actions {
-        match action {
-            DotfileAction::NewFile { target, .. } => {
-                println!("  ✓ Copied → {}", target.display());
-            }
-            DotfileAction::UpToDate { target } => {
-                println!("  ✓ {} — up to date", display_target(target));
-            }
-            DotfileAction::CleanUpdate { target, .. } => {
-                println!("  ✓ Updated → {}", target.display());
-            }
-            DotfileAction::LocalModification { target } => {
-                println!(
-                    "  ⚠ {} — local modification, skipped",
-                    display_target(target)
-                );
-            }
-            DotfileAction::Conflict { target, backup, .. } => {
-                println!(
-                    "  ⚠ Backed up {} → {}",
-                    display_target(target),
-                    backup.display()
-                );
-                println!("  ✓ Updated → {}", target.display());
-            }
-        }
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod apply;
 mod init;
 mod plan;
+mod report;
 mod status;
 mod sync;
 mod track;

--- a/src/cli/plan.rs
+++ b/src/cli/plan.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use crate::reconcile::{self, dotfiles::DotfileAction};
+use crate::reconcile;
 use crate::state::State;
 use std::path::Path;
 use std::process::ExitCode;
@@ -27,73 +27,14 @@ pub fn run(repo: Option<&Path>) -> anyhow::Result<ExitCode> {
         }
     };
 
-    // Print dotfiles results
     if let Some(ref dotfiles_report) = report.dotfiles {
-        if dotfiles_report.actions.is_empty() && dotfiles_report.errors.is_empty() {
-            println!("Dotfiles: nothing to do (source directory is empty)");
-        } else {
-            println!("Dotfiles:");
-            print_actions(&dotfiles_report.actions);
-            for err in &dotfiles_report.errors {
-                eprintln!("  ⚠ {err}");
-            }
-        }
+        super::report::print_plan_section("Dotfiles", dotfiles_report);
     }
-
-    // Print files results
     if let Some(ref files_report) = report.files {
-        if files_report.actions.is_empty() && files_report.errors.is_empty() {
-            println!("Files: nothing to do (source directory is empty)");
-        } else {
-            println!("Files:");
-            print_actions(&files_report.actions);
-            for err in &files_report.errors {
-                eprintln!("  ⚠ {err}");
-            }
-        }
+        super::report::print_plan_section("Files", files_report);
     }
-
-    // Print pending phase warnings
-    for phase in &report.pending_phases {
-        if let Some(ref reason) = phase.skipped_reason {
-            println!("⚠ {reason}");
-        }
-    }
+    super::report::print_pending_phases(&report);
 
     Ok(ExitCode::SUCCESS)
-}
-
-fn display_target(path: &std::path::Path) -> String {
-    path.file_name()
-        .map(|f| f.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.display().to_string())
-}
-
-fn print_actions(actions: &[DotfileAction]) {
-    for action in actions {
-        match action {
-            DotfileAction::NewFile { target, .. } => {
-                println!("  {} — new file", display_target(target));
-            }
-            DotfileAction::UpToDate { target } => {
-                println!("  {} — up to date", display_target(target));
-            }
-            DotfileAction::CleanUpdate { target, .. } => {
-                println!("  {} — clean update (repo changed)", display_target(target));
-            }
-            DotfileAction::LocalModification { target } => {
-                println!(
-                    "  {} — local modification (not in repo)",
-                    display_target(target)
-                );
-            }
-            DotfileAction::Conflict { target, .. } => {
-                println!(
-                    "  {} — conflict (both sides changed, will back up)",
-                    display_target(target)
-                );
-            }
-        }
-    }
 }
 

--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -1,0 +1,100 @@
+use crate::reconcile::dotfiles::DotfileAction;
+use crate::reconcile::ApplyReport;
+
+/// Format a target path for display, showing just the filename.
+pub fn display_target(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// Print plan-mode actions for a single section (dotfiles or files).
+pub fn print_plan_actions(actions: &[DotfileAction]) {
+    for action in actions {
+        match action {
+            DotfileAction::NewFile { target, .. } => {
+                println!("  {} — new file", display_target(target));
+            }
+            DotfileAction::UpToDate { target } => {
+                println!("  {} — up to date", display_target(target));
+            }
+            DotfileAction::CleanUpdate { target, .. } => {
+                println!("  {} — clean update (repo changed)", display_target(target));
+            }
+            DotfileAction::LocalModification { target } => {
+                println!(
+                    "  {} — local modification (not in repo)",
+                    display_target(target)
+                );
+            }
+            DotfileAction::Conflict { target, .. } => {
+                println!(
+                    "  {} — conflict (both sides changed, will back up)",
+                    display_target(target)
+                );
+            }
+        }
+    }
+}
+
+/// Print apply-mode actions for a single section (dotfiles or files).
+pub fn print_apply_actions(actions: &[DotfileAction]) {
+    for action in actions {
+        match action {
+            DotfileAction::NewFile { target, .. } => {
+                println!("  ✓ Copied → {}", target.display());
+            }
+            DotfileAction::UpToDate { target } => {
+                println!("  ✓ {} — up to date", display_target(target));
+            }
+            DotfileAction::CleanUpdate { target, .. } => {
+                println!("  ✓ Updated → {}", target.display());
+            }
+            DotfileAction::LocalModification { target } => {
+                println!(
+                    "  ⚠ {} — local modification, skipped",
+                    display_target(target)
+                );
+            }
+            DotfileAction::Conflict { target, backup, .. } => {
+                println!(
+                    "  ⚠ Backed up {} → {}",
+                    display_target(target),
+                    backup.display()
+                );
+                println!("  ✓ Updated → {}", target.display());
+            }
+        }
+    }
+}
+
+/// Print a section report (dotfiles or files) in plan mode.
+pub fn print_plan_section(label: &str, report: &crate::reconcile::dotfiles::Report) {
+    if report.actions.is_empty() && report.errors.is_empty() {
+        println!("{label}: nothing to do (source directory is empty)");
+    } else {
+        println!("{label}:");
+        print_plan_actions(&report.actions);
+        for err in &report.errors {
+            eprintln!("  ⚠ {err}");
+        }
+    }
+}
+
+/// Print a section report (dotfiles or files) in apply mode.
+pub fn print_apply_section(label: &str, report: &crate::reconcile::dotfiles::Report) {
+    println!("{label}:");
+    print_apply_actions(&report.actions);
+    for err in &report.errors {
+        eprintln!("  ✗ {err}");
+    }
+}
+
+/// Print pending phase warnings from an apply report.
+pub fn print_pending_phases(report: &ApplyReport) {
+    for phase in &report.pending_phases {
+        if let Some(ref reason) = phase.skipped_reason {
+            println!("⚠ {reason}");
+        }
+    }
+}

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,6 +1,6 @@
 use crate::config;
 use crate::git;
-use crate::reconcile::{self, dotfiles::DotfileAction};
+use crate::reconcile;
 use crate::state::State;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -84,71 +84,10 @@ fn run_apply(repo_path: &Path, state: &mut State) -> anyhow::Result<()> {
     };
 
     if let Some(ref dotfiles_report) = report.dotfiles {
-        println!("Dotfiles:");
-        for action in &dotfiles_report.actions {
-            match action {
-                DotfileAction::NewFile { target, .. } => {
-                    println!("  ✓ Copied → {}", target.display());
-                }
-                DotfileAction::UpToDate { target } => {
-                    println!("  ✓ {} — up to date", display_target(target));
-                }
-                DotfileAction::CleanUpdate { target, .. } => {
-                    println!("  ✓ Updated → {}", target.display());
-                }
-                DotfileAction::LocalModification { target } => {
-                    println!(
-                        "  ⚠ {} — local modification, skipped",
-                        display_target(target)
-                    );
-                }
-                DotfileAction::Conflict { target, backup, .. } => {
-                    println!(
-                        "  ⚠ Backed up {} → {}",
-                        display_target(target),
-                        backup.display()
-                    );
-                    println!("  ✓ Updated → {}", target.display());
-                }
-            }
-        }
-        for err in &dotfiles_report.errors {
-            eprintln!("  ✗ {err}");
-        }
+        super::report::print_apply_section("Dotfiles", dotfiles_report);
     }
-
     if let Some(ref files_report) = report.files {
-        println!("Files:");
-        for action in &files_report.actions {
-            match action {
-                DotfileAction::NewFile { target, .. } => {
-                    println!("  ✓ Copied → {}", target.display());
-                }
-                DotfileAction::UpToDate { target } => {
-                    println!("  ✓ {} — up to date", display_target(target));
-                }
-                DotfileAction::CleanUpdate { target, .. } => {
-                    println!("  ✓ Updated → {}", target.display());
-                }
-                DotfileAction::LocalModification { target } => {
-                    println!(
-                        "  ⚠ {} — local modification, skipped",
-                        display_target(target)
-                    );
-                }
-                DotfileAction::Conflict { target, backup, .. } => {
-                    println!(
-                        "  ⚠ Backed up {} → {}",
-                        display_target(target),
-                        backup.display()
-                    );
-                    println!("  ✓ Updated → {}", target.display());
-                }
-            }
-        }
-        for err in &files_report.errors {
-            eprintln!("  ✗ {err}");
-        }
+        super::report::print_apply_section("Files", files_report);
     }
 
     if state.repo_path().is_none() {
@@ -159,10 +98,4 @@ fn run_apply(repo_path: &Path, state: &mut State) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn display_target(path: &Path) -> String {
-    path.file_name()
-        .map(|f| f.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.display().to_string())
 }

--- a/src/reconcile/dotfiles.rs
+++ b/src/reconcile/dotfiles.rs
@@ -135,6 +135,34 @@ pub fn apply_files(
     apply_inner(&input, &config.target, false, state, repo_root, platform, machine_id)
 }
 
+/// Convert filemap diagnostics into human-readable error strings.
+fn collect_diagnostics(diagnostics: &[super::filemap::Diagnostic], errors: &mut Vec<String>) {
+    for diag in diagnostics {
+        match diag {
+            super::filemap::Diagnostic::MissingSource { layer, target, source } => {
+                errors.push(format!(
+                    "override source not found: {} (layer: {layer}, target: {target})",
+                    source.display()
+                ));
+            }
+            super::filemap::Diagnostic::UnknownPlatform { name } => {
+                errors.push(format!(
+                    "unknown platform name in config: {name} (known: linux, macos, windows)"
+                ));
+            }
+            super::filemap::Diagnostic::WalkSkip(msg) => {
+                errors.push(msg.clone());
+            }
+            super::filemap::Diagnostic::SourceOutsideRepo { layer, target, source } => {
+                errors.push(format!(
+                    "override source outside repo: {} (layer: {layer}, target: {target})",
+                    source.display()
+                ));
+            }
+        }
+    }
+}
+
 /// Shared plan logic: build file map, classify each file.
 fn plan_inner(
     input: &super::filemap::FileMapInput,
@@ -154,31 +182,7 @@ fn plan_inner(
     let (file_map, diagnostics) =
         super::filemap::build(input, repo_root, platform, machine_id)?;
 
-    // Report diagnostics as errors/warnings
-    for diag in &diagnostics {
-        match diag {
-            super::filemap::Diagnostic::MissingSource { layer, target, source } => {
-                report.errors.push(format!(
-                    "override source not found: {} (layer: {layer}, target: {target})",
-                    source.display()
-                ));
-            }
-            super::filemap::Diagnostic::UnknownPlatform { name } => {
-                report.errors.push(format!(
-                    "unknown platform name in config: {name} (known: linux, macos, windows)"
-                ));
-            }
-            super::filemap::Diagnostic::WalkSkip(msg) => {
-                report.errors.push(msg.clone());
-            }
-            super::filemap::Diagnostic::SourceOutsideRepo { layer, target, source } => {
-                report.errors.push(format!(
-                    "override source outside repo: {} (layer: {layer}, target: {target})",
-                    source.display()
-                ));
-            }
-        }
-    }
+    collect_diagnostics(&diagnostics, &mut report.errors);
 
     // Sort keys for deterministic output
     let mut targets: Vec<_> = file_map.keys().collect();
@@ -221,30 +225,7 @@ fn apply_inner(
     let (file_map, diagnostics) =
         super::filemap::build(input, repo_root, platform, machine_id)?;
 
-    for diag in &diagnostics {
-        match diag {
-            super::filemap::Diagnostic::MissingSource { layer, target, source } => {
-                report.errors.push(format!(
-                    "override source not found: {} (layer: {layer}, target: {target})",
-                    source.display()
-                ));
-            }
-            super::filemap::Diagnostic::UnknownPlatform { name } => {
-                report.errors.push(format!(
-                    "unknown platform name in config: {name} (known: linux, macos, windows)"
-                ));
-            }
-            super::filemap::Diagnostic::WalkSkip(msg) => {
-                report.errors.push(msg.clone());
-            }
-            super::filemap::Diagnostic::SourceOutsideRepo { layer, target, source } => {
-                report.errors.push(format!(
-                    "override source outside repo: {} (layer: {layer}, target: {target})",
-                    source.display()
-                ));
-            }
-        }
-    }
+    collect_diagnostics(&diagnostics, &mut report.errors);
 
     let mut targets: Vec<_> = file_map.keys().collect();
     targets.sort();

--- a/src/reconcile/mod.rs
+++ b/src/reconcile/mod.rs
@@ -55,26 +55,8 @@ pub fn plan(
 ) -> Result<ApplyReport, PlanError> {
     let mut report = ApplyReport::default();
 
-    // Phase 1: Pre-apply hooks (not yet implemented)
-    if !config.hooks.is_empty() {
-        let pre_hooks: Vec<_> = config
-            .hooks
-            .iter()
-            .filter(|h| h.when == crate::config::hooks::HookWhen::PreApply)
-            .collect();
-        if !pre_hooks.is_empty() {
-            report.pending_phases.push(PhaseReport {
-                phase: "pre-apply hooks".to_string(),
-                executed: false,
-                skipped_reason: Some(format!(
-                    "{} pre-apply hook(s) declared but hook execution is not yet implemented",
-                    pre_hooks.len()
-                )),
-            });
-        }
-    }
+    collect_pending_phases(config, &mut report);
 
-    // Phase 2: Dotfiles (active)
     if let Some(ref dotfiles_config) = config.dotfiles {
         let dotfiles_report =
             dotfiles::plan(dotfiles_config, state, repo_root, platform, machine_id)
@@ -82,43 +64,11 @@ pub fn plan(
         report.dotfiles = Some(dotfiles_report);
     }
 
-    // Phase 2b: Files (verbatim copy, no dot-prepend)
     if let Some(ref files_config) = config.files {
         let files_report =
             dotfiles::plan_files(files_config, state, repo_root, platform, machine_id)
                 .map_err(PlanError::Files)?;
         report.files = Some(files_report);
-    }
-
-    // Phase 3: Tools (not yet implemented)
-    if !config.tools.is_empty() {
-        report.pending_phases.push(PhaseReport {
-            phase: "tools".to_string(),
-            executed: false,
-            skipped_reason: Some(format!(
-                "{} tool(s) declared but tool installation is not yet implemented",
-                config.tools.len()
-            )),
-        });
-    }
-
-    // Phase 4: Post-apply hooks (not yet implemented)
-    if !config.hooks.is_empty() {
-        let post_hooks: Vec<_> = config
-            .hooks
-            .iter()
-            .filter(|h| h.when == crate::config::hooks::HookWhen::PostApply)
-            .collect();
-        if !post_hooks.is_empty() {
-            report.pending_phases.push(PhaseReport {
-                phase: "post-apply hooks".to_string(),
-                executed: false,
-                skipped_reason: Some(format!(
-                    "{} post-apply hook(s) declared but hook execution is not yet implemented",
-                    post_hooks.len()
-                )),
-            });
-        }
     }
 
     Ok(report)
@@ -134,40 +84,40 @@ pub fn apply(
 ) -> Result<ApplyReport, ApplyError> {
     let mut report = ApplyReport::default();
 
-    // Phase 1: Pre-apply hooks (not yet implemented)
-    if !config.hooks.is_empty() {
-        let pre_hooks: Vec<_> = config
-            .hooks
-            .iter()
-            .filter(|h| h.when == crate::config::hooks::HookWhen::PreApply)
-            .collect();
-        if !pre_hooks.is_empty() {
-            report.pending_phases.push(PhaseReport {
-                phase: "pre-apply hooks".to_string(),
-                executed: false,
-                skipped_reason: Some(format!(
-                    "{} pre-apply hook(s) declared but hook execution is not yet implemented",
-                    pre_hooks.len()
-                )),
-            });
-        }
-    }
+    collect_pending_phases(config, &mut report);
 
-    // Phase 2: Dotfiles (active)
     if let Some(ref dotfiles_config) = config.dotfiles {
         let dotfiles_report = dotfiles::apply(dotfiles_config, state, repo_root, platform, machine_id)
             .map_err(ApplyError::Dotfiles)?;
         report.dotfiles = Some(dotfiles_report);
     }
 
-    // Phase 2b: Files (verbatim copy, no dot-prepend)
     if let Some(ref files_config) = config.files {
         let files_report = dotfiles::apply_files(files_config, state, repo_root, platform, machine_id)
             .map_err(ApplyError::Files)?;
         report.files = Some(files_report);
     }
 
-    // Phase 3: Tools (not yet implemented)
+    Ok(report)
+}
+
+/// Populate pending-phase warnings for not-yet-implemented features.
+fn collect_pending_phases(config: &Config, report: &mut ApplyReport) {
+    let pre_hook_count = config
+        .hooks
+        .iter()
+        .filter(|h| h.when == crate::config::hooks::HookWhen::PreApply)
+        .count();
+    if pre_hook_count > 0 {
+        report.pending_phases.push(PhaseReport {
+            phase: "pre-apply hooks".to_string(),
+            executed: false,
+            skipped_reason: Some(format!(
+                "{pre_hook_count} pre-apply hook(s) declared but hook execution is not yet implemented"
+            )),
+        });
+    }
+
     if !config.tools.is_empty() {
         report.pending_phases.push(PhaseReport {
             phase: "tools".to_string(),
@@ -179,26 +129,20 @@ pub fn apply(
         });
     }
 
-    // Phase 4: Post-apply hooks (not yet implemented)
-    if !config.hooks.is_empty() {
-        let post_hooks: Vec<_> = config
-            .hooks
-            .iter()
-            .filter(|h| h.when == crate::config::hooks::HookWhen::PostApply)
-            .collect();
-        if !post_hooks.is_empty() {
-            report.pending_phases.push(PhaseReport {
-                phase: "post-apply hooks".to_string(),
-                executed: false,
-                skipped_reason: Some(format!(
-                    "{} post-apply hook(s) declared but hook execution is not yet implemented",
-                    post_hooks.len()
-                )),
-            });
-        }
+    let post_hook_count = config
+        .hooks
+        .iter()
+        .filter(|h| h.when == crate::config::hooks::HookWhen::PostApply)
+        .count();
+    if post_hook_count > 0 {
+        report.pending_phases.push(PhaseReport {
+            phase: "post-apply hooks".to_string(),
+            executed: false,
+            skipped_reason: Some(format!(
+                "{post_hook_count} post-apply hook(s) declared but hook execution is not yet implemented"
+            )),
+        });
     }
-
-    Ok(report)
 }
 
 /// Errors from plan operation.


### PR DESCRIPTION
## Summary

Removes three significant sources of code duplication across the CLI and reconcile modules.

### Changes

1. **Extract shared CLI report helpers** (`cli::report`)
   - `display_target`, `print_plan_actions`, `print_apply_actions`, `print_plan_section`, `print_apply_section`, and `print_pending_phases` consolidated into a new `cli::report` module.
   - Removes 3 duplicate copies from `cli::apply`, `cli::plan`, and `cli::sync` (sync had the worst duplication with fully inlined match arms for both dotfiles and files).

2. **Extract `collect_diagnostics` in `reconcile::dotfiles`**
   - The identical `match diag` block converting filemap diagnostics to error strings was duplicated between `plan_inner` and `apply_inner`. Now a single shared function.

3. **Extract `collect_pending_phases` in `reconcile`**
   - `plan()` and `apply()` duplicated identical logic for building pending-phase warnings (pre/post hooks, tools). Extracted into a shared helper. Also simplifies hook counting by using `.count()` instead of collecting into a Vec.

### Net impact

~150 lines removed across the three commits. All tests pass, clippy is clean.