### PR TITLE
refactor: deduplicate track.rs and reconcile file map setup

### DIFF
--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -52,6 +52,25 @@ pub fn run(repo: Option<&Path>, path: PathBuf) -> anyhow::Result<ExitCode> {
     track_new_file(&target_path, &cfg, &repo_root)
 }
 
+/// Try to resolve a target path against a config section's target directory,
+/// returning the state key and entry if the file is managed.
+fn resolve_managed_key<'a>(
+    target_path: &Path,
+    section_target: &str,
+    state: &'a State,
+) -> anyhow::Result<Option<(String, &'a crate::state::AppliedEntry)>> {
+    let target_base = expand_tilde(section_target)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let target_base = target_base.canonicalize().unwrap_or(target_base);
+    if let Ok(rel) = target_path.strip_prefix(&target_base) {
+        let key = rel.to_string_lossy().replace('\\', "/");
+        if let Some(entry) = state.applied.get(&key) {
+            return Ok(Some((key, entry)));
+        }
+    }
+    Ok(None)
+}
+
 /// Attempt to track a managed file (one that exists in state.applied).
 /// Returns `Some(ExitCode)` if we handled it, `None` if the file is not managed.
 fn try_track_managed(
@@ -60,32 +79,19 @@ fn try_track_managed(
     state: &State,
     repo_root: &Path,
 ) -> anyhow::Result<Option<ExitCode>> {
-    // Try matching against dotfiles target dir
-    if let Some(ref df) = cfg.dotfiles {
-        let target_base = expand_tilde(&df.target)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        // Canonicalize to handle symlinks (e.g. /var → /private/var on macOS)
-        let target_base = target_base.canonicalize().unwrap_or(target_base);
-        if let Ok(rel) = target_path.strip_prefix(&target_base) {
-            let key = rel.to_string_lossy().replace('\\', "/");
-            if let Some(entry) = state.applied.get(&key) {
-                return do_track_managed(target_path, entry, &key, &df.source, repo_root, state)
-                    .map(Some);
-            }
-        }
-    }
+    // Try each config section that has a target directory
+    let sections: Vec<(&str, &str)> = [
+        cfg.dotfiles.as_ref().map(|df| (df.target.as_str(), df.source.as_str())),
+        cfg.files.as_ref().map(|f| (f.target.as_str(), f.source.as_str())),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
 
-    // Try matching against files target dir
-    if let Some(ref files) = cfg.files {
-        let target_base = expand_tilde(&files.target)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let target_base = target_base.canonicalize().unwrap_or(target_base);
-        if let Ok(rel) = target_path.strip_prefix(&target_base) {
-            let key = rel.to_string_lossy().replace('\\', "/");
-            if let Some(entry) = state.applied.get(&key) {
-                return do_track_managed(target_path, entry, &key, &files.source, repo_root, state)
-                    .map(Some);
-            }
+    for (section_target, section_source) in sections {
+        if let Some((key, entry)) = resolve_managed_key(target_path, section_target, state)? {
+            return do_track_managed(target_path, entry, &key, section_source, repo_root, state)
+                .map(Some);
         }
     }
 
@@ -137,6 +143,36 @@ fn do_track_managed(
     Ok(ExitCode::SUCCESS)
 }
 
+/// Copy a file into the repo and print guidance for the user.
+fn copy_and_print_guidance(
+    target_path: &Path,
+    dest: &Path,
+    repo_root: &Path,
+    section_name: &str,
+    repo_filename: &str,
+) -> anyhow::Result<ExitCode> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
+    }
+    std::fs::copy(target_path, dest)
+        .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
+
+    let rel_dest = dest
+        .strip_prefix(repo_root)
+        .unwrap_or(dest)
+        .display();
+    println!("Copied {} → {}", target_path.display(), dest.display());
+    println!();
+    println!("Add to nostos.toml (file is not yet managed until you do):");
+    println!("  # The base source directory already covers this file.");
+    println!("  # If you need a platform/machine override, add:");
+    println!("  # [{section_name}.platforms.<os>]");
+    println!("  # \"{repo_filename}\" = \"{rel_dest}\"");
+
+    Ok(ExitCode::SUCCESS)
+}
+
 /// Track a new (unmanaged) file into the repo.
 fn track_new_file(
     target_path: &Path,
@@ -164,25 +200,7 @@ fn track_new_file(
 
         let stripped = filename.strip_prefix('.').unwrap_or(&filename);
         let dest = repo_root.join(&df.source).join(stripped);
-
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
-        }
-        std::fs::copy(target_path, &dest)
-            .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
-
-        let rel_dest = dest
-            .strip_prefix(repo_root)
-            .unwrap_or(&dest)
-            .display();
-        println!("Copied {} → {}", target_path.display(), dest.display());
-        println!();
-        println!("Add to nostos.toml (file is not yet managed until you do):");
-        println!("  # The base source directory already covers this file.");
-        println!("  # If you need a platform/machine override, add:");
-        println!("  # [dotfiles.platforms.<os>]");
-        println!("  # \"{stripped}\" = \"{rel_dest}\"");
+        copy_and_print_guidance(target_path, &dest, repo_root, "dotfiles", stripped)
     } else {
         let files = match cfg.files {
             Some(ref f) => f,
@@ -196,26 +214,6 @@ fn track_new_file(
         };
 
         let dest = repo_root.join(&files.source).join(&filename);
-
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
-        }
-        std::fs::copy(target_path, &dest)
-            .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
-
-        let rel_dest = dest
-            .strip_prefix(repo_root)
-            .unwrap_or(&dest)
-            .display();
-        println!("Copied {} → {}", target_path.display(), dest.display());
-        println!();
-        println!("Add to nostos.toml (file is not yet managed until you do):");
-        println!("  # The base source directory already covers this file.");
-        println!("  # If you need a platform/machine override, add:");
-        println!("  # [files.platforms.<os>]");
-        println!("  # \"{filename}\" = \"{rel_dest}\"");
+        copy_and_print_guidance(target_path, &dest, repo_root, "files", &filename)
     }
-
-    Ok(ExitCode::SUCCESS)
 }

--- a/src/reconcile/dotfiles.rs
+++ b/src/reconcile/dotfiles.rs
@@ -163,6 +163,56 @@ fn collect_diagnostics(diagnostics: &[super::filemap::Diagnostic], errors: &mut 
     }
 }
 
+/// Result of preparing the file map: validated source dir, resolved target,
+/// sorted file entries, and any diagnostic errors collected so far.
+struct PreparedFileMap {
+    target_base: PathBuf,
+    /// Sorted (target-relative key, absolute source path) pairs.
+    entries: Vec<(String, PathBuf)>,
+    /// Errors from diagnostics (non-fatal warnings).
+    errors: Vec<String>,
+}
+
+/// Shared setup for plan_inner and apply_inner: validate source dir,
+/// expand target, build file map, collect diagnostics, sort entries.
+fn prepare_file_map(
+    input: &super::filemap::FileMapInput,
+    target: &str,
+    prepend_dot: bool,
+    repo_root: &Path,
+    platform: &crate::platform::Platform,
+    machine_id: Option<&str>,
+) -> Result<PreparedFileMap, Error> {
+    let source_dir = repo_root.join(input.source);
+    check_source_dir(&source_dir)?;
+
+    let target_base = expand_tilde(target)?;
+    let mut errors = Vec::new();
+
+    let (file_map, diagnostics) =
+        super::filemap::build(input, repo_root, platform, machine_id)?;
+
+    collect_diagnostics(&diagnostics, &mut errors);
+
+    let mut keys: Vec<_> = file_map.keys().cloned().collect();
+    keys.sort();
+
+    let entries = keys
+        .into_iter()
+        .map(|rel_path| {
+            let src = file_map[&rel_path].clone();
+            let target_rel = if prepend_dot {
+                dot_prepend(&rel_path)
+            } else {
+                rel_path
+            };
+            (target_rel, src)
+        })
+        .collect();
+
+    Ok(PreparedFileMap { target_base, entries, errors })
+}
+
 /// Shared plan logic: build file map, classify each file.
 fn plan_inner(
     input: &super::filemap::FileMapInput,
@@ -173,31 +223,12 @@ fn plan_inner(
     platform: &crate::platform::Platform,
     machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    let source_dir = repo_root.join(input.source);
-    check_source_dir(&source_dir)?;
+    let prepared = prepare_file_map(input, target, prepend_dot, repo_root, platform, machine_id)?;
+    let mut report = Report { errors: prepared.errors, ..Default::default() };
 
-    let target_base = expand_tilde(target)?;
-    let mut report = Report::default();
-
-    let (file_map, diagnostics) =
-        super::filemap::build(input, repo_root, platform, machine_id)?;
-
-    collect_diagnostics(&diagnostics, &mut report.errors);
-
-    // Sort keys for deterministic output
-    let mut targets: Vec<_> = file_map.keys().collect();
-    targets.sort();
-
-    for rel_path in targets {
-        let src = &file_map[rel_path];
-        let target_rel = if prepend_dot {
-            dot_prepend(rel_path)
-        } else {
-            rel_path.clone()
-        };
-        let tgt = target_base.join(&target_rel);
-
-        match classify(src, &tgt, &target_rel, state) {
+    for (target_rel, src) in &prepared.entries {
+        let tgt = prepared.target_base.join(target_rel);
+        match classify(src, &tgt, target_rel, state) {
             Ok(action) => report.actions.push(action),
             Err(msg) => report.errors.push(msg),
         }
@@ -216,35 +247,18 @@ fn apply_inner(
     platform: &crate::platform::Platform,
     machine_id: Option<&str>,
 ) -> Result<Report, Error> {
-    let source_dir = repo_root.join(input.source);
-    check_source_dir(&source_dir)?;
+    let prepared = prepare_file_map(input, target, prepend_dot, repo_root, platform, machine_id)?;
+    let mut report = Report { errors: prepared.errors, ..Default::default() };
 
-    let target_base = expand_tilde(target)?;
-    let mut report = Report::default();
-
-    let (file_map, diagnostics) =
-        super::filemap::build(input, repo_root, platform, machine_id)?;
-
-    collect_diagnostics(&diagnostics, &mut report.errors);
-
-    let mut targets: Vec<_> = file_map.keys().collect();
-    targets.sort();
-
-    for rel_path in targets {
-        let src = &file_map[rel_path];
-        let target_rel = if prepend_dot {
-            dot_prepend(rel_path)
-        } else {
-            rel_path.clone()
-        };
-        let tgt = target_base.join(&target_rel);
+    for (target_rel, src) in &prepared.entries {
+        let tgt = prepared.target_base.join(target_rel);
 
         // Compute repo-relative source path for state tracking
         let source_rel = src.strip_prefix(repo_root)
             .map(|p| p.to_string_lossy().to_string())
             .ok();
 
-        let action = match classify(src, &tgt, &target_rel, state) {
+        let action = match classify(src, &tgt, target_rel, state) {
             Ok(action) => action,
             Err(msg) => {
                 report.errors.push(msg);
@@ -262,7 +276,7 @@ fn apply_inner(
                     continue;
                 }
                 state.applied.insert(
-                    target_rel,
+                    target_rel.clone(),
                     AppliedEntry {
                         hash: source_hash.clone(),
                         timestamp: chrono::Utc::now(),
@@ -288,7 +302,7 @@ fn apply_inner(
                     continue;
                 }
                 state.applied.insert(
-                    target_rel,
+                    target_rel.clone(),
                     AppliedEntry {
                         hash: source_hash.clone(),
                         timestamp: chrono::Utc::now(),


### PR DESCRIPTION
## Summary

Second batch of duplication removal, following #46.

### Changes

1. **`cli/track.rs` — extract `resolve_managed_key()`**
   Eliminates the repeated expand_tilde → canonicalize → strip_prefix → state lookup pattern that was duplicated for dotfiles and files sections. `try_track_managed` now iterates over config sections generically.

2. **`cli/track.rs` — extract `copy_and_print_guidance()`**
   Consolidates the repeated mkdir → copy → print user guidance that was duplicated in the dotfile and files branches of `track_new_file`.

3. **`reconcile/dotfiles.rs` — extract `prepare_file_map()`**
   `plan_inner` and `apply_inner` duplicated the same setup sequence: check_source_dir, expand_tilde, filemap::build, collect_diagnostics, sort keys, dot_prepend. Now a shared `PreparedFileMap` struct and `prepare_file_map()` function handles all of this. Both functions focus purely on their distinct per-file logic.

### Verification

- `cargo clippy --all-targets` — clean
- `cargo test` — all 10 tests pass