### PR TITLE
refactor: simplify hostname detection, add ADR for config struct duplication

### DIFF
--- a/docs/adr/0002-keep-separate-config-structs.md
+++ b/docs/adr/0002-keep-separate-config-structs.md
@@ -1,0 +1,37 @@
+# Keep separate DotfilesConfig and FilesConfig structs
+
+`DotfilesConfig` and `FilesConfig` are structurally identical today —
+both carry `source`, `target`, `platforms`, and `machines` fields with
+the same serde attributes. The two `From` impls that convert them into
+`FileMapInput` are also identical.
+
+We are deliberately keeping them as separate types for now rather than
+unifying into a shared generic struct.
+
+## Rationale
+
+The two sections have different *semantics* (dot-prepend vs verbatim
+copy) even though their *shapes* happen to match. As nostos evolves
+the sections may diverge — for example, `[files]` could gain
+permission-mode settings that don't apply to dotfiles, or `[dotfiles]`
+could gain an exclusion list. Premature unification would force
+awkward `Option` fields or trait gymnastics to re-separate them.
+
+## Decision
+
+Keep `DotfilesConfig` and `FilesConfig` as independent structs. Accept
+the small amount of structural duplication in exchange for the freedom
+to evolve each section independently. Revisit if a third section with
+the same shape appears or if the two structs remain identical after
+several milestones of feature work.
+
+## Considered Options
+
+- **Shared generic `SectionConfig`** — removes the duplicate struct
+  and collapses the two `From` impls. Risk: premature coupling makes
+  future divergence painful.
+- **Trait-based abstraction** — a `SyncSection` trait implemented by
+  both types. Adds indirection without clear benefit while the shapes
+  are trivially identical.
+- **Keep separate structs** (chosen) — a few lines of duplication,
+  but each type is free to evolve on its own schedule.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -188,21 +188,15 @@ fn default_state_path() -> Result<PathBuf, Error> {
 
 /// Detect the system hostname.
 fn detect_hostname() -> Option<String> {
-    // Try HOSTNAME env var first (common on Linux)
-    if let Ok(h) = std::env::var("HOSTNAME")
-        && !h.is_empty()
-    {
-        return Some(h);
-    }
+    first_nonempty_env(&["HOSTNAME", "COMPUTERNAME"])
+        .or_else(hostname_from_command)
+}
 
-    // Try COMPUTERNAME on Windows
-    if let Ok(h) = std::env::var("COMPUTERNAME")
-        && !h.is_empty()
-    {
-        return Some(h);
-    }
-
-    hostname_from_command()
+/// Return the value of the first environment variable that is set and non-empty.
+fn first_nonempty_env(vars: &[&str]) -> Option<String> {
+    vars.iter().find_map(|name| {
+        std::env::var(name).ok().filter(|v| !v.is_empty())
+    })
 }
 
 fn hostname_from_command() -> Option<String> {


### PR DESCRIPTION
## Summary

Two small cleanups to close out the duplication sweep.

### Changes

1. **`state/mod.rs` — `first_nonempty_env()` helper**
   Replaces the repeated if-let env var checks in `detect_hostname()` with a concise helper that returns the first set, non-empty variable from a list.

2. **ADR 0002 — Keep separate `DotfilesConfig` and `FilesConfig` structs**
   Documents the deliberate decision to accept the structural duplication between these two config types. They have identical shapes today but different semantics (dot-prepend vs verbatim copy), and premature unification would make future divergence painful. Revisit if a third section appears or if they remain identical after several milestones.

### Verification

- `cargo clippy --all-targets` — clean
- `cargo test` — all 10 tests pass