### PR TITLE
fix: use first-segment dot heuristic for track of nested paths

### DIFF
--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -173,20 +173,59 @@ fn copy_and_print_guidance(
     Ok(ExitCode::SUCCESS)
 }
 
-/// Track a new (unmanaged) file into the repo.
+/// Track a new (unmanaged) file into the repo using the first-segment dot heuristic.
+///
+/// Routing logic:
+/// 1. Compute the path relative to each section's target directory.
+/// 2. If the first segment of the relative path starts with `.`, route to `[dotfiles]`
+///    and strip the leading dot from that first segment only, preserving nested dirs.
+/// 3. Otherwise route to `[files]` verbatim.
 fn track_new_file(
     target_path: &Path,
     cfg: &config::Config,
     repo_root: &Path,
 ) -> anyhow::Result<ExitCode> {
-    let filename = target_path
-        .file_name()
-        .map(|f| f.to_string_lossy().to_string())
+    // Collect configured targets and try to compute a relative path
+    let targets: Vec<&str> = [
+        cfg.dotfiles.as_ref().map(|df| df.target.as_str()),
+        cfg.files.as_ref().map(|f| f.target.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    // Find the relative path from any configured target
+    let mut relative: Option<PathBuf> = None;
+    for &section_target in &targets {
+        let expanded = expand_tilde(section_target).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let expanded = expanded.canonicalize().unwrap_or(expanded);
+        if let Ok(rel) = target_path.strip_prefix(&expanded) {
+            relative = Some(rel.to_path_buf());
+            break;
+        }
+    }
+
+    let rel = match relative {
+        Some(r) => r,
+        None => {
+            eprintln!(
+                "Cannot track {}: not under any configured target directory",
+                target_path.display()
+            );
+            return Ok(ExitCode::from(3));
+        }
+    };
+
+    // Determine routing by checking first segment for leading dot
+    let first_segment = rel
+        .components()
+        .next()
+        .map(|c| c.as_os_str().to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let is_dotfile = filename.starts_with('.');
+    let needs_dotfiles = first_segment.starts_with('.');
 
-    if is_dotfile {
+    if needs_dotfiles {
         let df = match cfg.dotfiles {
             Some(ref df) => df,
             None => {
@@ -198,9 +237,15 @@ fn track_new_file(
             }
         };
 
-        let stripped = filename.strip_prefix('.').unwrap_or(&filename);
-        let dest = repo_root.join(&df.source).join(stripped);
-        copy_and_print_guidance(target_path, &dest, repo_root, "dotfiles", stripped)
+        // Strip leading dot from first segment, preserve rest of path
+        let stripped_first = first_segment.strip_prefix('.').unwrap_or(&first_segment);
+        let source_rel: PathBuf = std::iter::once(stripped_first)
+            .map(|s| Path::new(s).to_path_buf())
+            .chain(rel.components().skip(1).map(|c| PathBuf::from(c.as_os_str())))
+            .fold(PathBuf::new(), |acc, p| acc.join(p));
+        let source_rel_str = source_rel.to_string_lossy().replace('\\', "/");
+        let dest = repo_root.join(&df.source).join(&source_rel);
+        copy_and_print_guidance(target_path, &dest, repo_root, "dotfiles", &source_rel_str)
     } else {
         let files = match cfg.files {
             Some(ref f) => f,
@@ -213,7 +258,8 @@ fn track_new_file(
             }
         };
 
-        let dest = repo_root.join(&files.source).join(&filename);
-        copy_and_print_guidance(target_path, &dest, repo_root, "files", &filename)
+        let source_rel_str = rel.to_string_lossy().replace('\\', "/");
+        let dest = repo_root.join(&files.source).join(&rel);
+        copy_and_print_guidance(target_path, &dest, repo_root, "files", &source_rel_str)
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -824,6 +824,211 @@ fn track_new_plain_file_copies_to_files_dir() {
     );
 }
 
+#[test]
+fn track_new_nested_dotfile_preserves_directory_structure() {
+    let fix = TestFixture::new().with_default_config();
+
+    // Create ~/.config/nvim/init.vim in target (first segment .config starts with dot)
+    fix.add_target(".config/nvim/init.vim", "\" nvim config");
+
+    let target_path = fix.target_dir().join(".config/nvim/init.vim");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    // Should land at dotfiles/config/nvim/init.vim (dot stripped from first segment only)
+    let source_path = fix.dir.path().join("dotfiles/config/nvim/init.vim");
+    assert!(
+        source_path.exists(),
+        "nested dotfile should preserve directory structure"
+    );
+    assert_eq!(fs::read_to_string(&source_path).unwrap(), "\" nvim config");
+}
+
+#[test]
+fn track_new_nested_dotfile_local_bin() {
+    let fix = TestFixture::new().with_default_config();
+
+    // Create ~/.local/bin/foo in target
+    fix.add_target(".local/bin/foo", "#!/bin/sh\necho foo");
+
+    let target_path = fix.target_dir().join(".local/bin/foo");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    // Should land at dotfiles/local/bin/foo
+    let source_path = fix.dir.path().join("dotfiles/local/bin/foo");
+    assert!(
+        source_path.exists(),
+        "nested dotfile should preserve full directory nesting"
+    );
+    assert_eq!(
+        fs::read_to_string(&source_path).unwrap(),
+        "#!/bin/sh\necho foo"
+    );
+}
+
+#[test]
+fn track_new_mid_path_dot_routes_to_files() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n\n[files]\nsource = \"files/\"\ntarget = '{target}'\n"
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files")).unwrap();
+
+    // Create ~/projects/.envrc — first segment "projects" has no dot
+    fix.add_target("projects/.envrc", "# direnv");
+
+    let target_path = fix.target_dir().join("projects/.envrc");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    // Should go to files/projects/.envrc (mid-path dot is NOT first-segment routing)
+    let source_path = fix.dir.path().join("files/projects/.envrc");
+    assert!(
+        source_path.exists(),
+        "mid-path dotfile should route to files section"
+    );
+    assert_eq!(fs::read_to_string(&source_path).unwrap(), "# direnv");
+}
+
+#[test]
+fn track_new_nested_plain_file_preserves_directory_structure() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n\n[files]\nsource = \"files/\"\ntarget = '{target}'\n"
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files")).unwrap();
+
+    // Create ~/projects/scripts/deploy.sh — no dot anywhere in the path
+    fix.add_target("projects/scripts/deploy.sh", "#!/bin/sh\ndeploy");
+
+    let target_path = fix.target_dir().join("projects/scripts/deploy.sh");
+    fix.nostos()
+        .arg("track")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    // Should go to files/projects/scripts/deploy.sh with full nesting preserved
+    let source_path = fix.dir.path().join("files/projects/scripts/deploy.sh");
+    assert!(
+        source_path.exists(),
+        "nested plain file should preserve directory structure in files section"
+    );
+    assert_eq!(
+        fs::read_to_string(&source_path).unwrap(),
+        "#!/bin/sh\ndeploy"
+    );
+}
+
+// ── Shared-target collision tests ────────────────────────
+
+#[test]
+fn apply_shared_target_no_collision_between_dotfiles_and_files() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n\n\
+         [files]\nsource = \"files/\"\ntarget = '{target}'\n"
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files/config")).unwrap();
+
+    // Both sections have "config/starship.toml" in their source dirs
+    fix.add_source("config/starship.toml", "# dotfiles version");
+    let files_path = fix.dir.path().join("files/config/starship.toml");
+    fs::write(&files_path, "# files version").unwrap();
+
+    fix.nostos().arg("apply").assert().success();
+
+    // Dotfiles source "config/starship.toml" → target ".config/starship.toml" (dot-prepend)
+    assert_eq!(fix.read_target(".config/starship.toml"), "# dotfiles version");
+    // Files source "config/starship.toml" → target "config/starship.toml" (verbatim)
+    assert_eq!(fix.read_target("config/starship.toml"), "# files version");
+}
+
+#[test]
+fn track_shared_target_routes_dotfile_and_plain_to_correct_sections() {
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let config = format!(
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n\n\
+         [files]\nsource = \"files/\"\ntarget = '{target}'\n"
+    );
+    fs::write(fix.dir.path().join("nostos.toml"), &config).unwrap();
+    fs::create_dir_all(fix.dir.path().join("dotfiles")).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files")).unwrap();
+
+    // Place both files in target: .config/starship.toml and config/starship.toml
+    fix.add_target(".config/starship.toml", "# from dotfiles");
+    fix.add_target("config/starship.toml", "# from files");
+
+    // Track the dotfile version — first segment ".config" has dot → dotfiles section
+    let dotfile_target = fix.target_dir().join(".config/starship.toml");
+    fix.nostos()
+        .arg("track")
+        .arg(&dotfile_target)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    let dotfile_source = fix.dir.path().join("dotfiles/config/starship.toml");
+    assert!(
+        dotfile_source.exists(),
+        "dotfile should route to dotfiles/config/starship.toml"
+    );
+    assert_eq!(
+        fs::read_to_string(&dotfile_source).unwrap(),
+        "# from dotfiles"
+    );
+
+    // Track the plain version — first segment "config" has no dot → files section
+    let plain_target = fix.target_dir().join("config/starship.toml");
+    fix.nostos()
+        .arg("track")
+        .arg(&plain_target)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    let plain_source = fix.dir.path().join("files/config/starship.toml");
+    assert!(
+        plain_source.exists(),
+        "plain file should route to files/config/starship.toml"
+    );
+    assert_eq!(
+        fs::read_to_string(&plain_source).unwrap(),
+        "# from files"
+    );
+
+    // Cross-contamination check: dotfiles didn't get the plain file, files didn't get the dotfile
+    assert!(
+        !fix.dir.path().join("files/.config/starship.toml").exists(),
+        "files section should NOT contain .config/starship.toml"
+    );
+    assert!(
+        !fix.dir.path().join("dotfiles/.config/starship.toml").exists(),
+        "dotfiles section should NOT contain .config/starship.toml with leading dot"
+    );
+}
+
 // ── Sync tests ───────────────────────────────────────────
 
 /// A pair of git repos for testing sync: a bare "remote" and a local clone.


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

Fixes #49 — `nostos track` of new (unmanaged) files with nested paths now uses the first-segment dot heuristic (ADR 0003) instead of leaf-only routing.

## Changes

**`src/cli/track.rs`** — Rewrote `track_new_file` to:
1. Compute the relative path from each configured section's target directory
2. Check if the first path segment starts with `.` to determine routing
3. Strip the leading dot from only the first segment (preserving nested dirs) for dotfiles
4. Preserve full relative path structure when constructing the source destination

**`tests/cli.rs`** — Added integration tests:
- `track_new_nested_dotfile_preserves_directory_structure` (`~/.config/nvim/init.vim`)
- `track_new_nested_dotfile_local_bin` (`~/.local/bin/foo`)
- `track_new_mid_path_dot_routes_to_files` (`~/projects/.envrc`)

## Behavior examples

| Target path | Section | Source placed at |
|---|---|---|
| `~/.bashrc` | `[dotfiles]` | `<dotfiles.source>/bashrc` |
| `~/.config/nvim/init.vim` | `[dotfiles]` | `<dotfiles.source>/config/nvim/init.vim` |
| `~/.local/bin/foo` | `[dotfiles]` | `<dotfiles.source>/local/bin/foo` |
| `~/projects/.envrc` | `[files]` | `<files.source>/projects/.envrc` |

## Testing

All 165 tests pass. Clippy clean.