### PR TITLE
chore: add YAML frontmatter to post-merge-cleanup skill

### DIFF
--- a/.github/skills/post-merge-cleanup/SKILL.md
+++ b/.github/skills/post-merge-cleanup/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: post-merge-cleanup
+description: 'Update the local main branch and delete feature branches that have been merged (or squash-merged) via pull request. Use after a PR is merged, when the user says "cleanup branches", "update main", or "post-merge cleanup".'
+---
+
 # Post-Merge Cleanup Skill
 
 Update the local main branch and delete feature branches that have been


### PR DESCRIPTION
Add `name` and `description` frontmatter fields to the post-merge-cleanup skill, matching the format used by the design-review and use-feature-branch skills.