### PR TITLE
init: warn when hostname detection falls back to 'unknown'

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -70,7 +70,14 @@ impl State {
     /// Ensure machine identity is set. If not already present, detect from hostname.
     pub fn ensure_machine_identity(&mut self) {
         if self.machine.is_none() {
-            let id = detect_hostname().unwrap_or_else(|| "unknown".to_string());
+            let id = match detect_hostname() {
+                Some(name) => name,
+                None => {
+                    eprintln!("Warning: Could not detect hostname \u{2014} machine identity set to 'unknown'.");
+                    eprintln!("Use `nostos init --machine <name>` to set explicitly.");
+                    "unknown".to_string()
+                }
+            };
             self.machine = Some(MachineInfo { id });
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -182,6 +182,101 @@ fn init_with_machine_flag() {
 }
 
 #[test]
+#[cfg(unix)]
+fn init_with_machine_flag_no_fallback_warning() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    // Even with hostname detection suppressed, --machine should skip the fallback entirely
+    let restricted_bin = dir.path().join("restricted-bin");
+    fs::create_dir_all(&restricted_bin).unwrap();
+    std::os::unix::fs::symlink("/usr/bin/git", restricted_bin.join("git")).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .env_remove("HOSTNAME")
+        .env_remove("COMPUTERNAME")
+        .env("PATH", &restricted_bin)
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .arg("--machine")
+        .arg("my-server")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Could not detect hostname").not());
+
+    let state_path = fake_home.join("xdg-config/nostos/state.toml");
+    let state_content = fs::read_to_string(&state_path).unwrap();
+    assert!(state_content.contains("my-server"));
+}
+
+#[test]
+fn init_no_warning_when_hostname_detected() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .env("HOSTNAME", "test-host")
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Machine:    test-host"))
+        .stderr(predicate::str::contains("Could not detect hostname").not());
+}
+
+#[test]
+#[cfg(unix)]
+fn init_warns_on_hostname_fallback() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    // Build a minimal PATH that includes git but not hostname
+    let restricted_bin = dir.path().join("restricted-bin");
+    fs::create_dir_all(&restricted_bin).unwrap();
+    std::os::unix::fs::symlink("/usr/bin/git", restricted_bin.join("git")).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .env_remove("HOSTNAME")
+        .env_remove("COMPUTERNAME")
+        .env("PATH", &restricted_bin)
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Could not detect hostname"))
+        .stderr(predicate::str::contains("nostos init --machine"));
+
+    // Machine identity should still be set to "unknown"
+    let state_path = fake_home.join("xdg-config/nostos/state.toml");
+    let state_content = fs::read_to_string(&state_path).unwrap();
+    assert!(state_content.contains("id = \"unknown\""));
+}
+
+#[test]
 fn init_target_exists_errors() {
     let dir = TempDir::new().unwrap();
     let bare = create_bare_repo(dir.path());


### PR DESCRIPTION
When all hostname detection methods fail (`HOSTNAME`/`COMPUTERNAME` env vars and the `hostname` command), `ensure_machine_identity` now prints a warning to stderr before setting the identity to `"unknown"`. The warning directs the user to `nostos init --machine` for an explicit override.

The `"unknown"` fallback is preserved (not a hard error) so CI/containers without a hostname command can still operate.

## Changes

- **`src/state/mod.rs`** — `ensure_machine_identity` emits a stderr warning when `detect_hostname()` returns `None`
- **`tests/cli.rs`** — 3 new CLI integration tests:
  - `init_warns_on_hostname_fallback` — hostname detection suppressed → warning + `"unknown"` identity (`#[cfg(unix)]`)
  - `init_with_machine_flag_no_fallback_warning` — `--machine` bypasses fallback, no warning (`#[cfg(unix)]`)
  - `init_no_warning_when_hostname_detected` — `HOSTNAME` env set → no warning (cross-platform)

Closes #55
