### PR TITLE
sync: filename-aware commit messages

### DIFF
--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -19,8 +19,16 @@ pub fn run(repo: Option<&Path>, apply: bool) -> anyhow::Result<ExitCode> {
     let mut state = State::load().unwrap_or_default();
     state.ensure_machine_identity();
     let machine_id = state.machine_id().unwrap_or("unknown");
+    let changed_paths = match git::changed_paths(&repo_path) {
+        Ok(paths) => paths,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+    let commit_message = build_auto_sync_commit_message(machine_id, &changed_paths);
 
-    match git::commit(&repo_path, &format!("nostos: auto-sync from {machine_id}")) {
+    match git::commit(&repo_path, &commit_message) {
         Ok(git::CommitOutcome::Committed) => {
             println!("Committed local changes");
         }
@@ -68,6 +76,44 @@ fn resolve_repo_path(explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
     anyhow::bail!("No repo path configured — run `nostos init` first");
 }
 
+fn build_auto_sync_commit_message(machine_id: &str, changed_paths: &[String]) -> String {
+    let prefix = format!("nostos: auto-sync from {machine_id}");
+    if changed_paths.is_empty() {
+        return prefix;
+    }
+
+    let filenames: Vec<String> = changed_paths
+        .iter()
+        .map(|path| leaf_filename(path))
+        .collect();
+    let total = filenames.len();
+    let shown = total.min(3);
+    let remaining = total.saturating_sub(shown);
+    let summary = format_filename_summary(&filenames[..shown], remaining);
+
+    format!("{prefix} — {total} file(s): {summary}")
+}
+
+fn leaf_filename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.rsplit('/').next().unwrap_or(path).to_string())
+}
+
+fn format_filename_summary(filenames: &[String], remaining: usize) -> String {
+    match filenames {
+        [] => String::new(),
+        [only] if remaining == 0 => only.clone(),
+        [first, second] if remaining == 0 => format!("{first} and {second}"),
+        [first, second, third] if remaining == 0 => format!("{first}, {second}, and {third}"),
+        _ => {
+            let listed = filenames.join(", ");
+            format!("{listed}, and {remaining} more")
+        }
+    }
+}
+
 fn run_apply(repo_path: &Path, state: &mut State) -> anyhow::Result<()> {
     let config_path = repo_path.join("nostos.toml");
     let cfg = match config::load(&config_path) {
@@ -105,4 +151,64 @@ fn run_apply(repo_path: &Path, state: &mut State) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_auto_sync_commit_message;
+
+    #[test]
+    fn auto_sync_commit_message_uses_leaf_filenames() {
+        let changed = vec![
+            "dotfiles/bashrc".to_string(),
+            "config/git/gitconfig".to_string(),
+        ];
+
+        let message = build_auto_sync_commit_message("work-macbook", &changed);
+
+        assert_eq!(
+            message,
+            "nostos: auto-sync from work-macbook — 2 file(s): bashrc and gitconfig"
+        );
+    }
+
+    #[test]
+    fn auto_sync_commit_message_lists_three_filenames() {
+        let changed = vec![
+            "dotfiles/bashrc".to_string(),
+            "dotfiles/gitconfig".to_string(),
+            "dotfiles/zshrc".to_string(),
+        ];
+
+        let message = build_auto_sync_commit_message("work-macbook", &changed);
+
+        assert_eq!(
+            message,
+            "nostos: auto-sync from work-macbook — 3 file(s): bashrc, gitconfig, and zshrc"
+        );
+    }
+
+    #[test]
+    fn auto_sync_commit_message_appends_remaining_count() {
+        let changed = vec![
+            "dotfiles/bashrc".to_string(),
+            "dotfiles/gitconfig".to_string(),
+            "dotfiles/zshrc".to_string(),
+            "dotfiles/tmux.conf".to_string(),
+        ];
+
+        let message = build_auto_sync_commit_message("work-macbook", &changed);
+
+        assert_eq!(
+            message,
+            "nostos: auto-sync from work-macbook — 4 file(s): bashrc, gitconfig, zshrc, and 1 more"
+        );
+    }
+
+    #[test]
+    fn auto_sync_commit_message_falls_back_to_prefix_when_clean() {
+        let message = build_auto_sync_commit_message("work-macbook", &[]);
+
+        assert_eq!(message, "nostos: auto-sync from work-macbook");
+    }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -140,6 +140,34 @@ pub fn is_clean(repo: &Path) -> Result<bool, Error> {
     Ok(output.trim().is_empty())
 }
 
+/// Return repo-relative paths for changed files from `git status --porcelain=v1 -z`.
+///
+/// Uses `--untracked-files=all` so untracked directories are expanded to files,
+/// and `--find-renames` so rename entries report their destination path.
+pub fn changed_paths(repo: &Path) -> Result<Vec<String>, Error> {
+    ensure_repo(repo)?;
+
+    let output = Command::new("git")
+        .args([
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--find-renames",
+            "-z",
+        ])
+        .current_dir(repo)
+        .output()
+        .map_err(|_| Error::GitNotFound)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let path = repo.display().to_string();
+        return Err(classify_error("status", &path, &stderr));
+    }
+
+    Ok(parse_porcelain_paths(&output.stdout))
+}
+
 /// Stage all changes and commit with the given message.
 ///
 /// Returns [`CommitOutcome::NothingToCommit`] if the working tree is already
@@ -291,6 +319,29 @@ fn run_git(repo: &Path, args: &[&str]) -> Result<String, Error> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn parse_porcelain_paths(output: &[u8]) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut entries = output
+        .split(|byte| *byte == b'\0')
+        .filter(|entry| !entry.is_empty());
+
+    while let Some(entry) = entries.next() {
+        if entry.len() < 4 {
+            continue;
+        }
+
+        paths.push(String::from_utf8_lossy(&entry[3..]).to_string());
+
+        let x = entry[0] as char;
+        let y = entry[1] as char;
+        if matches!(x, 'R' | 'C') || matches!(y, 'R' | 'C') {
+            let _ = entries.next();
+        }
+    }
+
+    paths
 }
 
 /// Classify a git stderr message into a typed error variant.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1294,6 +1294,22 @@ fn run_git(cwd: &std::path::Path, args: &[&str]) {
     );
 }
 
+fn run_git_stdout(cwd: &std::path::Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git should be available");
+    assert!(
+        out.status.success(),
+        "git {:?} in {} failed: {}",
+        args,
+        cwd.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).expect("git stdout should be utf-8")
+}
+
 #[test]
 fn track_no_dotfiles_section_errors() {
     let fix = TestFixture::new();
@@ -1398,10 +1414,17 @@ fn sync_dirty_working_tree_auto_commits() {
     .unwrap();
 
     fix.nostos_sync()
+        .env("HOSTNAME", "work-macbook")
         .assert()
         .success()
         .stdout(predicate::str::contains("Committed local changes"))
         .stdout(predicate::str::contains("Pushed to remote"));
+
+    let message = run_git_stdout(&fix.local_path(), &["log", "-1", "--pretty=%s"]);
+    assert_eq!(
+        message.trim(),
+        "nostos: auto-sync from work-macbook — 1 file(s): vimrc"
+    );
 }
 
 #[test]

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -142,6 +142,45 @@ fn commit_returns_nothing_to_commit_on_clean_tree() {
 }
 
 #[test]
+fn changed_paths_lists_repo_relative_files() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    init_repo(dir.path());
+
+    fs::create_dir_all(dir.path().join("dotfiles")).unwrap();
+    fs::write(dir.path().join("dotfiles/bashrc"), "content").unwrap();
+    fs::write(dir.path().join("gitconfig"), "content").unwrap();
+
+    let paths = git::changed_paths(dir.path()).unwrap();
+
+    assert_eq!(paths, vec!["dotfiles/bashrc", "gitconfig"]);
+}
+
+#[test]
+fn changed_paths_reports_rename_destination() {
+    require_git!();
+    let dir = TempDir::new().unwrap();
+    init_repo(dir.path());
+
+    fs::write(dir.path().join("old name.txt"), "content").unwrap();
+    git::commit(dir.path(), "initial").unwrap();
+    fs::rename(
+        dir.path().join("old name.txt"),
+        dir.path().join("new name.txt"),
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git add failed");
+
+    let paths = git::changed_paths(dir.path()).unwrap();
+
+    assert_eq!(paths, vec!["new name.txt"]);
+}
+
+#[test]
 fn clone_creates_working_copy() {
     require_git!();
     let remote_dir = TempDir::new().unwrap();


### PR DESCRIPTION
Generate commit messages that include file count and up to 3 leaf filenames from changed files, replacing the old static `nostos: auto-sync from <host>` message.

Closes #52

> *This was generated by AI during triage.*