### PR TITLE
init: state-based detection and --dest flag

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -3,12 +3,21 @@ use crate::state::{MachineInfo, State};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-pub fn run(url: String, machine: Option<String>, apply: bool) -> anyhow::Result<ExitCode> {
-    let dest = default_dotfiles_path()?;
+pub fn run(
+    url: String,
+    machine: Option<String>,
+    apply: bool,
+    dest: Option<PathBuf>,
+) -> anyhow::Result<ExitCode> {
+    let dest = dest.unwrap_or(default_dotfiles_path()?);
+    let mut state = State::load().unwrap_or_default();
 
-    if dest.exists() {
+    if let Some(repo_path) = state.repo_path().map(PathBuf::from)
+        && repo_path.exists()
+    {
         eprintln!(
-            "Target directory already exists — use `nostos sync` to update an existing repo"
+            "nostos is already initialized at {} — use `nostos sync` to update an existing repo",
+            repo_path.display()
         );
         return Ok(ExitCode::from(3));
     }
@@ -19,9 +28,6 @@ pub fn run(url: String, machine: Option<String>, apply: bool) -> anyhow::Result<
         eprintln!("Error: {e}");
         return Ok(ExitCode::from(3));
     }
-
-    // Load or create state
-    let mut state = State::load().unwrap_or_default();
 
     // Set machine identity
     if let Some(ref id) = machine {
@@ -48,10 +54,7 @@ pub fn run(url: String, machine: Option<String>, apply: bool) -> anyhow::Result<
     println!();
     println!("Repository: {}", dest.display());
     println!("Platform:   {platform}");
-    println!(
-        "Machine:    {}",
-        state.machine_id().unwrap_or("unknown")
-    );
+    println!("Machine:    {}", state.machine_id().unwrap_or("unknown"));
     println!("Files:      {file_count} would be applied");
 
     if apply {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -34,6 +34,9 @@ pub enum Command {
         /// Apply dotfiles after cloning
         #[arg(long)]
         apply: bool,
+        /// Destination path for the cloned dotfiles repo
+        #[arg(long)]
+        dest: Option<std::path::PathBuf>,
     },
     /// Show platform info and config validity
     Status,
@@ -58,7 +61,12 @@ pub enum Command {
 pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
     let repo = cli.repo.as_deref();
     match cli.command {
-        Command::Init { url, machine, apply } => init::run(url, machine, apply),
+        Command::Init {
+            url,
+            machine,
+            apply,
+            dest,
+        } => init::run(url, machine, apply, dest),
         Command::Status => status::run(repo),
         Command::Plan => plan::run(repo),
         Command::Apply => apply::run(repo),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,7 @@
 //! CLI integration tests — single-command tests for status, plan, apply.
 
 use assert_cmd::Command;
+use nostos::state::State;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
@@ -120,10 +121,20 @@ fn create_bare_repo(dir: &std::path::Path) -> std::path::PathBuf {
     bare
 }
 
+fn state_path(home: &std::path::Path) -> std::path::PathBuf {
+    home.join("xdg-config/nostos/state.toml")
+}
+
+fn write_state_repo_path(home: &std::path::Path, repo_path: &std::path::Path) {
+    let mut state = State::default();
+    state.set_repo_path(repo_path.to_string_lossy().into_owned());
+    state.save_to(&state_path(home)).unwrap();
+}
+
 // ── Init tests ───────────────────────────────────────────
 
 #[test]
-fn init_clones_repo_and_sets_state() {
+fn init_clones_to_default_dest_and_sets_state() {
     let dir = TempDir::new().unwrap();
     let bare = create_bare_repo(dir.path());
     let fake_home = dir.path().join("fakehome");
@@ -148,9 +159,9 @@ fn init_clones_repo_and_sets_state() {
     assert!(fake_home.join(".dotfiles").exists());
 
     // State file should contain repo path and machine identity
-    let state_path = fake_home.join("xdg-config/nostos/state.toml");
+    let state_path = state_path(&fake_home);
     let state_content = fs::read_to_string(&state_path).unwrap();
-    assert!(state_content.contains(".dotfiles"));
+    assert!(state_content.contains(fake_home.join(".dotfiles").to_string_lossy().as_ref()));
     assert!(state_content.contains("[machine]"));
 }
 
@@ -277,11 +288,14 @@ fn init_warns_on_hostname_fallback() {
 }
 
 #[test]
-fn init_target_exists_errors() {
+fn init_errors_when_state_records_existing_repo_path() {
     let dir = TempDir::new().unwrap();
     let bare = create_bare_repo(dir.path());
     let fake_home = dir.path().join("fakehome");
-    fs::create_dir_all(fake_home.join(".dotfiles")).unwrap();
+    let existing_repo = dir.path().join("existing-dotfiles");
+    fs::create_dir_all(&fake_home).unwrap();
+    fs::create_dir_all(&existing_repo).unwrap();
+    write_state_repo_path(&fake_home, &existing_repo);
 
     Command::cargo_bin("nostos")
         .unwrap()
@@ -294,7 +308,62 @@ fn init_target_exists_errors() {
         .arg(bare.to_str().unwrap())
         .assert()
         .code(3)
-        .stderr(predicate::str::contains("Target directory already exists"));
+        .stderr(predicate::str::contains("nostos sync"))
+        .stderr(predicate::str::contains(existing_repo.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn init_allows_recovery_when_state_repo_path_is_missing() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    let missing_repo = dir.path().join("missing-dotfiles");
+    fs::create_dir_all(&fake_home).unwrap();
+    write_state_repo_path(&fake_home, &missing_repo);
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .assert()
+        .success();
+
+    assert!(fake_home.join(".dotfiles").exists());
+    let state_content = fs::read_to_string(state_path(&fake_home)).unwrap();
+    assert!(state_content.contains(fake_home.join(".dotfiles").to_string_lossy().as_ref()));
+}
+
+#[test]
+fn init_with_dest_flag_clones_to_custom_path() {
+    let dir = TempDir::new().unwrap();
+    let bare = create_bare_repo(dir.path());
+    let fake_home = dir.path().join("fakehome");
+    let custom_dest = dir.path().join("custom-dotfiles");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    Command::cargo_bin("nostos")
+        .unwrap()
+        .env("HOME", &fake_home)
+        .env(
+            "XDG_CONFIG_HOME",
+            fake_home.join("xdg-config").to_str().unwrap(),
+        )
+        .arg("init")
+        .arg(bare.to_str().unwrap())
+        .arg("--dest")
+        .arg(&custom_dest)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(custom_dest.to_string_lossy().as_ref()));
+
+    assert!(custom_dest.exists());
+    let state_content = fs::read_to_string(state_path(&fake_home)).unwrap();
+    assert!(state_content.contains(custom_dest.to_string_lossy().as_ref()));
 }
 
 #[test]


### PR DESCRIPTION
Replaces fragile directory-existence check with state-based detection and adds `--dest` flag for custom clone destinations.

Closes #51

> *This was generated by AI during triage.*