### PR TITLE
feat: recursive directory track with auto-detection and copy-back

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,10 +44,13 @@ pub enum Command {
     Plan,
     /// Apply dotfiles from the repo to this machine
     Apply,
-    /// Track a target file back into the repo
+    /// Track a target file or directory back into the repo
     Track {
-        /// Path to the target file to track back into the repo
+        /// Path to the target file or directory to track back into the repo
         path: std::path::PathBuf,
+        /// Remove orphaned source files (only meaningful for directory track)
+        #[arg(long)]
+        prune: bool,
     },
     /// Sync the local dotfiles repo with the remote
     Sync {
@@ -70,7 +73,7 @@ pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         Command::Status => status::run(repo),
         Command::Plan => plan::run(repo),
         Command::Apply => apply::run(repo),
-        Command::Track { path } => track::run(repo, path),
+        Command::Track { path, prune: _ } => track::run(repo, path),
         Command::Sync { apply } => sync::run(repo, apply),
     }
 }

--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -1,6 +1,6 @@
 use crate::config;
-use crate::reconcile::dotfiles::{expand_tilde, hash_file};
-use crate::state::State;
+use crate::reconcile::dotfiles::{expand_tilde, hash_file, walk_dir};
+use crate::state::{AppliedEntry, State};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -43,6 +43,11 @@ pub fn run(repo: Option<&Path>, path: PathBuf) -> anyhow::Result<ExitCode> {
         anyhow::anyhow!("cannot resolve path {}: {e}", path.display())
     })?;
 
+    // Directory detection: if path is a directory, enter recursive mode
+    if target_path.is_dir() {
+        return track_directory(&target_path, &cfg, &repo_root, &state);
+    }
+
     // Try to find the file in state (managed file case)
     if let Some(result) = try_track_managed(&target_path, &cfg, &state, &repo_root)? {
         return Ok(result);
@@ -50,6 +55,218 @@ pub fn run(repo: Option<&Path>, path: PathBuf) -> anyhow::Result<ExitCode> {
 
     // New file case — use dot heuristic
     track_new_file(&target_path, &cfg, &repo_root)
+}
+
+/// Recursively track all files in a target directory back into the repo.
+fn track_directory(
+    target_dir: &Path,
+    cfg: &config::Config,
+    repo_root: &Path,
+    state: &State,
+) -> anyhow::Result<ExitCode> {
+    // Walk the target directory
+    let (files, _skips) = walk_dir(target_dir)
+        .map_err(|e| anyhow::anyhow!("cannot walk directory {}: {e}", target_dir.display()))?;
+
+    // Resolve configured target directories (expanded and canonicalized)
+    let sections = resolve_sections(cfg)?;
+
+    let mut updated = 0u32;
+    let mut new_count = 0u32;
+    let mut errors: Vec<String> = Vec::new();
+    let mut state = state.clone();
+
+    for rel_file in &files {
+        let abs_file = target_dir.join(rel_file.replace('/', std::path::MAIN_SEPARATOR_STR));
+
+        // Try to route this file to a config section
+        let Some(routing) = route_file(&abs_file, &sections)? else {
+            continue;
+        };
+
+        // Check if this file is already managed (in state)
+        let state_key = &routing.state_key;
+        if state.applied.contains_key(state_key) {
+            // Managed file: copy target → source, update state
+            let source_rel = match state.applied[state_key].source.as_deref() {
+                Some(s) => s.to_string(),
+                None => routing.source_rel.clone(),
+            };
+            let source_path = repo_root.join(&source_rel);
+
+            if let Err(e) = copy_file(&abs_file, &source_path) {
+                errors.push(format!("{}: {e}", abs_file.display()));
+                continue;
+            }
+
+            let new_hash = match hash_file(&abs_file) {
+                Ok(h) => h,
+                Err(e) => {
+                    errors.push(format!("{}: cannot hash: {e}", abs_file.display()));
+                    continue;
+                }
+            };
+            if let Some(applied) = state.applied.get_mut(state_key) {
+                applied.hash = new_hash;
+                applied.timestamp = chrono::Utc::now();
+            }
+            updated += 1;
+        } else {
+            // New file: copy target → source, create state entry
+            let source_path = repo_root.join(&routing.source_rel);
+
+            if let Err(e) = copy_file(&abs_file, &source_path) {
+                errors.push(format!("{}: {e}", abs_file.display()));
+                continue;
+            }
+
+            let new_hash = match hash_file(&abs_file) {
+                Ok(h) => h,
+                Err(e) => {
+                    errors.push(format!("{}: cannot hash: {e}", abs_file.display()));
+                    continue;
+                }
+            };
+            state.applied.insert(
+                state_key.clone(),
+                AppliedEntry {
+                    hash: new_hash,
+                    timestamp: chrono::Utc::now(),
+                    source: Some(routing.source_rel.clone()),
+                },
+            );
+            new_count += 1;
+        }
+    }
+
+    let total = updated + new_count;
+    if total == 0 && errors.is_empty() {
+        println!("No files to track in {}", target_dir.display());
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    if total > 0 && let Err(e) = state.save() {
+        eprintln!("Warning: failed to save state: {e}");
+    }
+
+    if total > 0 {
+        println!("Tracked {total} files: {updated} updated, {new_count} new");
+    }
+
+    if !errors.is_empty() {
+        for err in &errors {
+            eprintln!("error: {err}");
+        }
+        return Ok(ExitCode::from(1));
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Routing information for a single file discovered during directory walk.
+struct FileRouting {
+    /// The key used in state.applied (target-relative with dot prepended).
+    state_key: String,
+    /// Repo-relative source path (e.g., "dotfiles/config/starship.toml").
+    source_rel: String,
+}
+
+/// A resolved config section with its expanded target directory.
+struct ResolvedSection {
+    /// Expanded + canonicalized target directory.
+    target_dir: PathBuf,
+    /// Source directory relative to repo root (e.g., "dotfiles/").
+    source_dir: String,
+    /// Whether this is a dotfiles section (dot-prepend/strip applies).
+    is_dotfiles: bool,
+}
+
+/// Resolve all configured sections into expanded target paths.
+fn resolve_sections(cfg: &config::Config) -> anyhow::Result<Vec<ResolvedSection>> {
+    let mut sections = Vec::new();
+
+    if let Some(ref df) = cfg.dotfiles {
+        let expanded = expand_tilde(&df.target).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let canonical = expanded.canonicalize().unwrap_or(expanded);
+        sections.push(ResolvedSection {
+            target_dir: canonical,
+            source_dir: df.source.clone(),
+            is_dotfiles: true,
+        });
+    }
+
+    if let Some(ref f) = cfg.files {
+        let expanded = expand_tilde(&f.target).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let canonical = expanded.canonicalize().unwrap_or(expanded);
+        sections.push(ResolvedSection {
+            target_dir: canonical,
+            source_dir: f.source.clone(),
+            is_dotfiles: false,
+        });
+    }
+
+    Ok(sections)
+}
+
+/// Route a target file to a config section using longest-prefix matching.
+fn route_file(
+    abs_path: &Path,
+    sections: &[ResolvedSection],
+) -> anyhow::Result<Option<FileRouting>> {
+    // Find the section with the longest matching target prefix
+    let mut best: Option<(usize, &ResolvedSection)> = None;
+
+    for section in sections {
+        if let Ok(rel) = abs_path.strip_prefix(&section.target_dir) {
+            let prefix_len = section.target_dir.as_os_str().len();
+            if best.is_none() || prefix_len > best.unwrap().0 {
+                best = Some((prefix_len, section));
+            }
+            let _ = rel; // used only for strip_prefix check
+        }
+    }
+
+    let Some((_, section)) = best else {
+        return Ok(None);
+    };
+
+    let rel = abs_path.strip_prefix(&section.target_dir).unwrap();
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+
+    if section.is_dotfiles {
+        // rel_str is already target-relative with dot (e.g., ".bashrc", ".config/starship.toml")
+        // State key = target-relative path as-is (matches what apply stores)
+        let state_key = rel_str.clone();
+
+        // Source = "dotfiles/" + strip_leading_dot(rel_str) = "dotfiles/bashrc"
+        let stripped = rel_str.strip_prefix('.').unwrap_or(&rel_str);
+        let source_rel = format!("{}{stripped}", section.source_dir);
+
+        Ok(Some(FileRouting {
+            state_key,
+            source_rel,
+        }))
+    } else {
+        // For [files]: state key = target-relative path, source = "files/" + rel
+        let state_key = rel_str.clone();
+        let source_rel = format!("{}{rel_str}", section.source_dir);
+
+        Ok(Some(FileRouting {
+            state_key,
+            source_rel,
+        }))
+    }
+}
+
+/// Copy a file, creating parent directories as needed.
+fn copy_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
+    }
+    std::fs::copy(src, dest)
+        .map_err(|e| anyhow::anyhow!("cannot copy {} → {}: {e}", src.display(), dest.display()))?;
+    Ok(())
 }
 
 /// Try to resolve a target path against a config section's target directory,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1622,3 +1622,197 @@ fn sync_cherry_pick_in_progress_exits_with_error() {
         .failure()
         .stderr(predicate::str::contains("cherry-pick"));
 }
+
+// ── Recursive directory track tests ──────────────────────────────
+
+#[test]
+fn track_directory_copies_managed_files_back_and_updates_state() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original bash");
+    fix.add_source("config/starship.toml", "# original starship");
+
+    // Apply to create targets and state
+    fix.nostos().arg("apply").assert().success();
+
+    // Edit both target files
+    fix.add_target(".bashrc", "# edited bash");
+    fix.add_target(".config/starship.toml", "# edited starship");
+
+    // Track the entire target directory
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked 2 files"));
+
+    // Verify sources were updated
+    let bash_src = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(bash_src, "# edited bash");
+    let star_src =
+        fs::read_to_string(fix.dir.path().join("dotfiles/config/starship.toml")).unwrap();
+    assert_eq!(star_src, "# edited starship");
+
+    // Verify subsequent apply sees everything up to date
+    fix.nostos()
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date"));
+}
+
+#[test]
+fn track_directory_imports_new_files_into_source_and_state() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original");
+
+    // Apply to set up state
+    fix.nostos().arg("apply").assert().success();
+
+    // Add a new file directly in the target (not managed yet)
+    fix.add_target(".config/nvim/init.lua", "-- nvim config");
+
+    // Track the entire target directory
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 new"));
+
+    // Verify the new file was imported into source tree with dot stripped
+    let imported = fs::read_to_string(
+        fix.dir.path().join("dotfiles/config/nvim/init.lua"),
+    )
+    .unwrap();
+    assert_eq!(imported, "-- nvim config");
+
+    // Verify subsequent apply deploys it back (i.e., state was registered)
+    fix.nostos()
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date"));
+}
+
+#[test]
+fn track_directory_routes_files_to_correct_section() {
+    // Config with both [dotfiles] (target = <home>) and [files] (target = <home>/bin)
+    let fix = TestFixture::new();
+    let target = fix.target_dir().to_string_lossy().to_string();
+    let bin_target = fix.target_dir().join("bin").to_string_lossy().to_string();
+    fs::create_dir_all(&bin_target).unwrap();
+    fs::create_dir_all(fix.dir.path().join("files")).unwrap();
+
+    let config = format!(
+        "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n\n\
+         [files]\nsource = \"files/\"\ntarget = '{bin_target}'\n"
+    );
+    let fix = fix.with_config(&config);
+
+    fix.add_source("bashrc", "# bash");
+    // Add a file in the files source
+    let files_src = fix.dir.path().join("files/myscript");
+    fs::write(&files_src, "#!/bin/sh").unwrap();
+
+    // Apply to get state populated
+    fix.nostos().arg("apply").assert().success();
+
+    // Edit both targets
+    fix.add_target(".bashrc", "# edited bash");
+    fix.add_target("bin/myscript", "#!/bin/sh\n# edited");
+
+    // Track from the home dir — should route .bashrc → dotfiles, bin/myscript → files
+    fix.nostos()
+        .arg("track")
+        .arg(&target)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2 updated"));
+
+    // Verify routing: dotfile went to dotfiles/
+    let bash_src = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(bash_src, "# edited bash");
+
+    // Verify routing: plain file went to files/ (longest-prefix match on bin/)
+    let script_src = fs::read_to_string(fix.dir.path().join("files/myscript")).unwrap();
+    assert_eq!(script_src, "#!/bin/sh\n# edited");
+}
+
+#[test]
+fn track_directory_applies_dot_strip_inversion_for_new_dotfiles() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# bash");
+
+    // Apply so we have state
+    fix.nostos().arg("apply").assert().success();
+
+    // Add new nested dotfile in target: .config/alacritty/alacritty.toml
+    fix.add_target(".config/alacritty/alacritty.toml", "[font]\nsize = 14");
+
+    // Track the directory
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 new"));
+
+    // Verify dot was stripped: lands in dotfiles/config/alacritty/alacritty.toml
+    let imported = fs::read_to_string(
+        fix.dir.path().join("dotfiles/config/alacritty/alacritty.toml"),
+    )
+    .unwrap();
+    assert_eq!(imported, "[font]\nsize = 14");
+}
+
+#[test]
+fn track_directory_prints_correct_summary_with_mixed_counts() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# bash");
+    fix.add_source("gitconfig", "# git");
+
+    // Apply
+    fix.nostos().arg("apply").assert().success();
+
+    // Edit one existing file, add one new file
+    fix.add_target(".bashrc", "# edited bash");
+    fix.add_target(".vimrc", "\" new vim config");
+
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked 3 files: 2 updated, 1 new"));
+}
+
+#[test]
+fn track_prune_flag_ignored_for_single_file() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original");
+
+    // Apply to create state
+    fix.nostos().arg("apply").assert().success();
+
+    // Edit target
+    fix.add_target(".bashrc", "# edited");
+
+    // Track with --prune — should succeed and behave like normal track
+    let target_path = fix.target_dir().join(".bashrc");
+    fix.nostos()
+        .arg("track")
+        .arg("--prune")
+        .arg(&target_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked"));
+
+    // Source was updated
+    let source = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(source, "# edited");
+}


### PR DESCRIPTION
## Summary

Extends `nostos track` to auto-detect when the provided path is a directory and perform a recursive track of all files within it, completing the apply ↔ track symmetry for directories.

## What's implemented

- **Directory auto-detection**: When the canonicalized path is a directory, enters recursive mode automatically (no flag needed)
- **Target directory walk**: Uses the existing `walk_dir` function (skips symlinks, `.git` dirs)
- **Section routing**: Longest-prefix matching against configured target directories routes files to the correct `[dotfiles]` or `[files]` section
- **Dot-strip inversion**: For `[dotfiles]` paths, strips the leading dot from the first segment (`.config/nvim/init.lua` → `config/nvim/init.lua`)
- **Managed file update**: Files already in state get copied back and their hash/timestamp updated
- **New file import**: Unmanaged files discovered in the target are imported into the source tree with state registration
- **Summary output**: Prints "Tracked N files: X updated, Y new"
- **`--prune` flag**: Accepted by the CLI parser (no-op; behavior implemented in #69)
- **Graceful partial failure**: Errors on individual files are collected and reported; successfully processed files still get their state saved

## Testing

6 new integration tests covering all behaviors:
- `track_directory_copies_managed_files_back_and_updates_state`
- `track_directory_imports_new_files_into_source_and_state`
- `track_directory_routes_files_to_correct_section`
- `track_directory_applies_dot_strip_inversion_for_new_dotfiles`
- `track_directory_prints_correct_summary_with_mixed_counts`
- `track_prune_flag_ignored_for_single_file`

All 204 tests pass, clippy clean.

## Parent issue

Closes #68 (child of #66)

## Follow-ups

- #69 — Orphan detection and `--prune` behavior (blocked by this PR)
- #70 — Symlink and `.git` skip warnings with summary output (blocked by this PR)
