### PR TITLE
feat: symlink and .git skip warnings with summary output

### DIFF
--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -65,8 +65,15 @@ fn track_directory(
     state: &State,
 ) -> anyhow::Result<ExitCode> {
     // Walk the target directory
-    let (files, _skips) = walk_dir(target_dir)
+    let (files, skips) = walk_dir(target_dir)
         .map_err(|e| anyhow::anyhow!("cannot walk directory {}: {e}", target_dir.display()))?;
+    let skipped_symlinks = skips
+        .iter()
+        .filter(|skip| skip.starts_with("skipping symlink: "))
+        .count();
+    for skip in &skips {
+        eprintln!("{skip}");
+    }
 
     // Resolve configured target directories (expanded and canonicalized)
     let sections = resolve_sections(cfg)?;
@@ -142,6 +149,9 @@ fn track_directory(
     let total = updated + new_count;
     if total == 0 && errors.is_empty() {
         println!("No files to track in {}", target_dir.display());
+        if skipped_symlinks > 0 {
+            println!("Skipped {skipped_symlinks} symlinks");
+        }
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -151,6 +161,9 @@ fn track_directory(
 
     if total > 0 {
         println!("Tracked {total} files: {updated} updated, {new_count} new");
+        if skipped_symlinks > 0 {
+            println!("Skipped {skipped_symlinks} symlinks");
+        }
     }
 
     if !errors.is_empty() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1791,6 +1791,59 @@ fn track_directory_prints_correct_summary_with_mixed_counts() {
         .stdout(predicate::str::contains("Tracked 3 files: 2 updated, 1 new"));
 }
 
+#[cfg(unix)]
+#[test]
+fn track_directory_skips_symlinks_with_warning() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original bash");
+
+    fix.nostos().arg("apply").assert().success();
+    fix.add_target(".bashrc", "# edited bash");
+
+    std::os::unix::fs::symlink(".bashrc", fix.target_dir().join(".zshrc")).unwrap();
+
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked 1 files: 1 updated, 0 new"))
+        .stdout(predicate::str::contains("Skipped 1 symlinks"))
+        .stderr(predicate::str::contains("skipping symlink: .zshrc"));
+
+    let bash_src = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(bash_src, "# edited bash");
+    assert!(!fix.dir.path().join("dotfiles/zshrc").exists());
+}
+
+#[test]
+fn track_directory_skips_git_directory_silently() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original bash");
+
+    fix.nostos().arg("apply").assert().success();
+    fix.add_target(".bashrc", "# edited bash");
+
+    let git_dir = fix.target_dir().join(".git");
+    fs::create_dir_all(git_dir.join("hooks")).unwrap();
+    fs::write(git_dir.join("hooks/pre-commit"), "#!/bin/sh\nexit 0\n").unwrap();
+
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracked 1 files: 1 updated, 0 new"))
+        .stdout(predicate::str::contains("Skipped").not())
+        .stderr(predicate::str::contains("skipping").not());
+
+    let bash_src = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(bash_src, "# edited bash");
+    assert!(!fix.dir.path().join("dotfiles/git").exists());
+}
+
 #[test]
 fn track_prune_flag_ignored_for_single_file() {
     let fix = TestFixture::new().with_default_config();


### PR DESCRIPTION
Closes #70

## Summary

Adds clear feedback about skipped entries during recursive directory track:

- Symlinks encountered during target walk produce a warning on stderr with the relative path
- `.git` directories are skipped silently (no output)
- Final summary includes a "Skipped N symlinks" line on stdout when symlinks were encountered

## Tests

- E2E test: target dir with symlink → skipped with warning, other files tracked
- E2E test: target dir with `.git` subdirectory → silently skipped
- All existing tests pass