### PR TITLE
feat: orphan detection and --prune for recursive directory track

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -73,7 +73,7 @@ pub fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         Command::Status => status::run(repo),
         Command::Plan => plan::run(repo),
         Command::Apply => apply::run(repo),
-        Command::Track { path, prune: _ } => track::run(repo, path),
+        Command::Track { path, prune } => track::run(repo, path, prune),
         Command::Sync { apply } => sync::run(repo, apply),
     }
 }

--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -1,10 +1,11 @@
 use crate::config;
 use crate::reconcile::dotfiles::{expand_tilde, hash_file, walk_dir};
 use crate::state::{AppliedEntry, State};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-pub fn run(repo: Option<&Path>, path: PathBuf) -> anyhow::Result<ExitCode> {
+pub fn run(repo: Option<&Path>, path: PathBuf, prune: bool) -> anyhow::Result<ExitCode> {
     let state = State::load().unwrap_or_default();
 
     // Resolve repo root: explicit flag > state > cwd (if nostos.toml exists)
@@ -39,13 +40,13 @@ pub fn run(repo: Option<&Path>, path: PathBuf) -> anyhow::Result<ExitCode> {
             .map_err(|e| anyhow::anyhow!("cannot determine current directory: {e}"))?
             .join(&path)
     };
-    let target_path = target_path.canonicalize().map_err(|e| {
-        anyhow::anyhow!("cannot resolve path {}: {e}", path.display())
-    })?;
+    let target_path = target_path
+        .canonicalize()
+        .map_err(|e| anyhow::anyhow!("cannot resolve path {}: {e}", path.display()))?;
 
     // Directory detection: if path is a directory, enter recursive mode
     if target_path.is_dir() {
-        return track_directory(&target_path, &cfg, &repo_root, &state);
+        return track_directory(&target_path, &cfg, &repo_root, &state, prune);
     }
 
     // Try to find the file in state (managed file case)
@@ -63,6 +64,7 @@ fn track_directory(
     cfg: &config::Config,
     repo_root: &Path,
     state: &State,
+    prune: bool,
 ) -> anyhow::Result<ExitCode> {
     // Walk the target directory
     let (files, _skips) = walk_dir(target_dir)
@@ -71,82 +73,126 @@ fn track_directory(
     // Resolve configured target directories (expanded and canonicalized)
     let sections = resolve_sections(cfg)?;
 
-    let mut updated = 0u32;
-    let mut new_count = 0u32;
-    let mut errors: Vec<String> = Vec::new();
-    let mut state = state.clone();
-
+    let mut planned = Vec::new();
+    let mut encountered_targets = HashSet::new();
     for rel_file in &files {
         let abs_file = target_dir.join(rel_file.replace('/', std::path::MAIN_SEPARATOR_STR));
+        encountered_targets.insert(abs_file.clone());
 
         // Try to route this file to a config section
         let Some(routing) = route_file(&abs_file, &sections)? else {
             continue;
         };
 
-        // Check if this file is already managed (in state)
-        let state_key = &routing.state_key;
-        if state.applied.contains_key(state_key) {
-            // Managed file: copy target → source, update state
-            let source_rel = match state.applied[state_key].source.as_deref() {
-                Some(s) => s.to_string(),
-                None => routing.source_rel.clone(),
-            };
-            let source_path = repo_root.join(&source_rel);
+        let is_managed = state.applied.contains_key(&routing.state_key);
+        planned.push(PlannedTrack {
+            abs_file,
+            state_key: routing.state_key,
+            source_rel: routing.source_rel,
+            is_managed,
+        });
+    }
 
-            if let Err(e) = copy_file(&abs_file, &source_path) {
-                errors.push(format!("{}: {e}", abs_file.display()));
+    let orphans = find_orphans(target_dir, repo_root, &sections, &encountered_targets)?;
+    if !orphans.is_empty() && !prune {
+        eprintln!("Orphaned source files found:");
+        for orphan in &orphans {
+            eprintln!("{}", orphan.source_rel);
+        }
+        return Ok(ExitCode::from(1));
+    }
+
+    let mut updated = 0u32;
+    let mut new_count = 0u32;
+    let mut pruned = 0u32;
+    let mut errors: Vec<String> = Vec::new();
+    let mut state = state.clone();
+
+    if prune {
+        for orphan in &orphans {
+            if let Err(e) = std::fs::remove_file(&orphan.abs_path) {
+                errors.push(format!("{}: cannot prune: {e}", orphan.abs_path.display()));
                 continue;
             }
+            state.applied.remove(&orphan.state_key);
+            pruned += 1;
+        }
+    }
 
-            let new_hash = match hash_file(&abs_file) {
-                Ok(h) => h,
-                Err(e) => {
-                    errors.push(format!("{}: cannot hash: {e}", abs_file.display()));
+    if errors.is_empty() {
+        for plan in &planned {
+            if plan.is_managed {
+                // Managed file: copy target → source, update state
+                let source_rel = match state
+                    .applied
+                    .get(&plan.state_key)
+                    .and_then(|entry| entry.source.as_deref())
+                {
+                    Some(source_rel) => source_rel.to_string(),
+                    None => plan.source_rel.clone(),
+                };
+                let source_path = repo_root.join(&source_rel);
+
+                if let Err(e) = copy_file(&plan.abs_file, &source_path) {
+                    errors.push(format!("{}: {e}", plan.abs_file.display()));
                     continue;
                 }
-            };
-            if let Some(applied) = state.applied.get_mut(state_key) {
-                applied.hash = new_hash;
-                applied.timestamp = chrono::Utc::now();
-            }
-            updated += 1;
-        } else {
-            // New file: copy target → source, create state entry
-            let source_path = repo_root.join(&routing.source_rel);
 
-            if let Err(e) = copy_file(&abs_file, &source_path) {
-                errors.push(format!("{}: {e}", abs_file.display()));
-                continue;
-            }
+                let new_hash = match hash_file(&plan.abs_file) {
+                    Ok(h) => h,
+                    Err(e) => {
+                        errors.push(format!("{}: cannot hash: {e}", plan.abs_file.display()));
+                        continue;
+                    }
+                };
+                if let Some(applied) = state.applied.get_mut(&plan.state_key) {
+                    applied.hash = new_hash;
+                    applied.timestamp = chrono::Utc::now();
+                }
+                updated += 1;
+            } else {
+                // New file: copy target → source, create state entry
+                let source_path = repo_root.join(&plan.source_rel);
 
-            let new_hash = match hash_file(&abs_file) {
-                Ok(h) => h,
-                Err(e) => {
-                    errors.push(format!("{}: cannot hash: {e}", abs_file.display()));
+                if let Err(e) = copy_file(&plan.abs_file, &source_path) {
+                    errors.push(format!("{}: {e}", plan.abs_file.display()));
                     continue;
                 }
-            };
-            state.applied.insert(
-                state_key.clone(),
-                AppliedEntry {
-                    hash: new_hash,
-                    timestamp: chrono::Utc::now(),
-                    source: Some(routing.source_rel.clone()),
-                },
-            );
-            new_count += 1;
+
+                let new_hash = match hash_file(&plan.abs_file) {
+                    Ok(h) => h,
+                    Err(e) => {
+                        errors.push(format!("{}: cannot hash: {e}", plan.abs_file.display()));
+                        continue;
+                    }
+                };
+                state.applied.insert(
+                    plan.state_key.clone(),
+                    AppliedEntry {
+                        hash: new_hash,
+                        timestamp: chrono::Utc::now(),
+                        source: Some(plan.source_rel.clone()),
+                    },
+                );
+                new_count += 1;
+            }
         }
     }
 
     let total = updated + new_count;
-    if total == 0 && errors.is_empty() {
+    if total == 0 && pruned == 0 && errors.is_empty() {
         println!("No files to track in {}", target_dir.display());
         return Ok(ExitCode::SUCCESS);
     }
 
-    if total > 0 && let Err(e) = state.save() {
+    if (total > 0 || pruned > 0)
+        && let Err(e) = state.save()
+    {
         eprintln!("Warning: failed to save state: {e}");
+    }
+
+    if pruned > 0 {
+        println!("Pruned {pruned} orphaned source files");
     }
 
     if total > 0 {
@@ -179,6 +225,24 @@ struct ResolvedSection {
     source_dir: String,
     /// Whether this is a dotfiles section (dot-prepend/strip applies).
     is_dotfiles: bool,
+}
+
+struct PlannedTrack {
+    abs_file: PathBuf,
+    state_key: String,
+    source_rel: String,
+    is_managed: bool,
+}
+
+struct OrphanedSource {
+    source_rel: String,
+    state_key: String,
+    abs_path: PathBuf,
+}
+
+struct SourceScope {
+    source_root: PathBuf,
+    section_rel_prefix: String,
 }
 
 /// Resolve all configured sections into expanded target paths.
@@ -259,6 +323,135 @@ fn route_file(
 }
 
 /// Copy a file, creating parent directories as needed.
+fn find_orphans(
+    target_dir: &Path,
+    repo_root: &Path,
+    sections: &[ResolvedSection],
+    encountered_targets: &HashSet<PathBuf>,
+) -> anyhow::Result<Vec<OrphanedSource>> {
+    let mut orphans = Vec::new();
+    let mut seen = HashSet::new();
+
+    for section in sections {
+        let Some(scope) = source_scope_for_track(target_dir, repo_root, section) else {
+            continue;
+        };
+        if !scope.source_root.exists() {
+            continue;
+        }
+
+        let (source_files, _skips) = walk_dir(&scope.source_root).map_err(|e| {
+            anyhow::anyhow!(
+                "cannot walk source directory {}: {e}",
+                scope.source_root.display()
+            )
+        })?;
+
+        for source_file in source_files {
+            if source_file.starts_with("platforms/") || source_file.starts_with("machines/") {
+                continue;
+            }
+
+            let section_rel = join_rel(&scope.section_rel_prefix, &source_file);
+            let source_rel = join_repo_rel(&section.source_dir, &section_rel);
+            if !seen.insert(source_rel.clone()) {
+                continue;
+            }
+
+            let state_key = source_rel_to_state_key(&section_rel, section.is_dotfiles);
+            let target_path = section
+                .target_dir
+                .join(state_key.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if target_path.starts_with(target_dir) && !encountered_targets.contains(&target_path) {
+                orphans.push(OrphanedSource {
+                    abs_path: repo_root.join(&source_rel),
+                    source_rel,
+                    state_key,
+                });
+            }
+        }
+    }
+
+    orphans.sort_by(|a, b| a.source_rel.cmp(&b.source_rel));
+    Ok(orphans)
+}
+
+fn source_scope_for_track(
+    target_dir: &Path,
+    repo_root: &Path,
+    section: &ResolvedSection,
+) -> Option<SourceScope> {
+    if let Ok(rel) = target_dir.strip_prefix(&section.target_dir) {
+        let rel = rel.to_string_lossy().replace('\\', "/");
+        let section_rel_prefix = target_rel_to_source_rel(&rel, section.is_dotfiles)?;
+        return Some(SourceScope {
+            source_root: repo_root.join(join_repo_rel(&section.source_dir, &section_rel_prefix)),
+            section_rel_prefix,
+        });
+    }
+
+    if section.target_dir.starts_with(target_dir) {
+        return Some(SourceScope {
+            source_root: repo_root.join(&section.source_dir),
+            section_rel_prefix: String::new(),
+        });
+    }
+
+    None
+}
+
+fn target_rel_to_source_rel(target_rel: &str, is_dotfiles: bool) -> Option<String> {
+    if target_rel.is_empty() {
+        return Some(String::new());
+    }
+    if !is_dotfiles {
+        return Some(target_rel.to_string());
+    }
+
+    let mut parts = target_rel.split('/');
+    let first = parts.next()?;
+    let stripped = first.strip_prefix('.')?;
+    let mut source_rel = stripped.to_string();
+    for part in parts {
+        source_rel.push('/');
+        source_rel.push_str(part);
+    }
+    Some(source_rel)
+}
+
+fn source_rel_to_state_key(source_rel: &str, is_dotfiles: bool) -> String {
+    if !is_dotfiles {
+        return source_rel.to_string();
+    }
+
+    if source_rel.is_empty() {
+        return String::new();
+    }
+
+    format!(".{source_rel}")
+}
+
+fn join_rel(prefix: &str, rel: &str) -> String {
+    if prefix.is_empty() {
+        rel.to_string()
+    } else if rel.is_empty() {
+        prefix.to_string()
+    } else {
+        format!("{prefix}/{rel}")
+    }
+}
+
+fn join_repo_rel(base: &str, rel: &str) -> String {
+    if rel.is_empty() {
+        return PathBuf::from(base).to_string_lossy().replace('\\', "/");
+    }
+
+    PathBuf::from(base)
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 fn copy_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
@@ -276,8 +469,7 @@ fn resolve_managed_key<'a>(
     section_target: &str,
     state: &'a State,
 ) -> anyhow::Result<Option<(String, &'a crate::state::AppliedEntry)>> {
-    let target_base = expand_tilde(section_target)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let target_base = expand_tilde(section_target).map_err(|e| anyhow::anyhow!("{e}"))?;
     let target_base = target_base.canonicalize().unwrap_or(target_base);
     if let Ok(rel) = target_path.strip_prefix(&target_base) {
         let key = rel.to_string_lossy().replace('\\', "/");
@@ -307,8 +499,7 @@ fn try_track_managed(
 
     for section_target in sections {
         if let Some((key, entry)) = resolve_managed_key(target_path, section_target, state)? {
-            return do_track_managed(target_path, entry, &key, repo_root, state)
-                .map(Some);
+            return do_track_managed(target_path, entry, &key, repo_root, state).map(Some);
         }
     }
 
@@ -339,8 +530,13 @@ fn do_track_managed(
         std::fs::create_dir_all(parent)
             .map_err(|e| anyhow::anyhow!("cannot create directory {}: {e}", parent.display()))?;
     }
-    std::fs::copy(target_path, &source_path)
-        .map_err(|e| anyhow::anyhow!("cannot copy {} → {}: {e}", target_path.display(), source_path.display()))?;
+    std::fs::copy(target_path, &source_path).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot copy {} → {}: {e}",
+            target_path.display(),
+            source_path.display()
+        )
+    })?;
 
     let new_hash = hash_file(target_path)
         .map_err(|e| anyhow::anyhow!("cannot hash {}: {e}", target_path.display()))?;
@@ -378,10 +574,7 @@ fn copy_and_print_guidance(
     std::fs::copy(target_path, dest)
         .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
 
-    let rel_dest = dest
-        .strip_prefix(repo_root)
-        .unwrap_or(dest)
-        .display();
+    let rel_dest = dest.strip_prefix(repo_root).unwrap_or(dest).display();
     println!("Copied {} → {}", target_path.display(), dest.display());
     println!();
     println!("Add to nostos.toml (file is not yet managed until you do):");
@@ -461,7 +654,11 @@ fn track_new_file(
         let stripped_first = first_segment.strip_prefix('.').unwrap_or(&first_segment);
         let source_rel: PathBuf = std::iter::once(stripped_first)
             .map(|s| Path::new(s).to_path_buf())
-            .chain(rel.components().skip(1).map(|c| PathBuf::from(c.as_os_str())))
+            .chain(
+                rel.components()
+                    .skip(1)
+                    .map(|c| PathBuf::from(c.as_os_str())),
+            )
             .fold(PathBuf::new(), |acc, p| acc.join(p));
         let source_rel_str = source_rel.to_string_lossy().replace('\\', "/");
         let dest = repo_root.join(&df.source).join(&source_rel);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -105,9 +105,13 @@ fn create_bare_repo(dir: &std::path::Path) -> std::path::PathBuf {
         .expect("git add");
     std::process::Command::new("git")
         .args([
-            "-c", "user.name=test",
-            "-c", "user.email=test@test.com",
-            "commit", "-m", "initial",
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@test.com",
+            "commit",
+            "-m",
+            "initial",
         ])
         .current_dir(&work)
         .output()
@@ -309,7 +313,9 @@ fn init_errors_when_state_records_existing_repo_path() {
         .assert()
         .code(3)
         .stderr(predicate::str::contains("nostos sync"))
-        .stderr(predicate::str::contains(existing_repo.to_string_lossy().as_ref()));
+        .stderr(predicate::str::contains(
+            existing_repo.to_string_lossy().as_ref(),
+        ));
 }
 
 #[test]
@@ -359,7 +365,9 @@ fn init_with_dest_flag_clones_to_custom_path() {
         .arg(&custom_dest)
         .assert()
         .success()
-        .stdout(predicate::str::contains(custom_dest.to_string_lossy().as_ref()));
+        .stdout(predicate::str::contains(
+            custom_dest.to_string_lossy().as_ref(),
+        ));
 
     assert!(custom_dest.exists());
     let state_content = fs::read_to_string(state_path(&fake_home)).unwrap();
@@ -406,9 +414,13 @@ fn init_with_apply_copies_files() {
         .expect("git add");
     std::process::Command::new("git")
         .args([
-            "-c", "user.name=test",
-            "-c", "user.email=test@test.com",
-            "commit", "-m", "initial",
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@test.com",
+            "commit",
+            "-m",
+            "initial",
         ])
         .current_dir(&work)
         .output()
@@ -572,12 +584,12 @@ fn plan_with_mixed_states() {
         .arg("plan")
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("new file").and(predicate::str::contains("up to date").or(
+        .stdout(predicate::str::contains("new file").and(
+            predicate::str::contains("up to date").or(
                 // Unmanaged existing file with matching content
                 predicate::str::contains("conflict"),
-            )),
-        );
+            ),
+        ));
 }
 
 // ── Apply tests ──────────────────────────────────────────
@@ -658,11 +670,7 @@ fn apply_conflict_creates_backup() {
     let backups: Vec<_> = fs::read_dir(&home)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_name()
-                .to_string_lossy()
-                .contains("nostos-backup")
-        })
+        .filter(|e| e.file_name().to_string_lossy().contains("nostos-backup"))
         .collect();
     assert!(!backups.is_empty(), "backup file should exist");
 }
@@ -781,7 +789,9 @@ install.apt = "fd-find"
         .current_dir(fixture.dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("2 tool(s) declared but tool installation is not yet implemented"));
+        .stdout(predicate::str::contains(
+            "2 tool(s) declared but tool installation is not yet implemented",
+        ));
 }
 
 #[test]
@@ -811,7 +821,9 @@ when = "pre-apply"
         .current_dir(fixture.dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("hook execution is not yet implemented"));
+        .stdout(predicate::str::contains(
+            "hook execution is not yet implemented",
+        ));
 }
 
 #[test]
@@ -890,7 +902,9 @@ target = '{target}'
         .arg("status")
         .assert()
         .success()
-        .stdout(predicate::str::contains(format!("Layers:    base + {platform}")));
+        .stdout(predicate::str::contains(format!(
+            "Layers:    base + {platform}"
+        )));
 }
 
 #[test]
@@ -1042,7 +1056,10 @@ fn track_new_dotfile_copies_without_dot() {
     // Verify file went to dotfiles source dir without the dot prefix
     let source_path = fix.dir.path().join("dotfiles").join("newrc");
     assert!(source_path.exists(), "source file should exist without dot");
-    assert_eq!(fs::read_to_string(&source_path).unwrap(), "# brand new dotfile");
+    assert_eq!(
+        fs::read_to_string(&source_path).unwrap(),
+        "# brand new dotfile"
+    );
 }
 
 #[test]
@@ -1068,7 +1085,10 @@ fn track_new_plain_file_copies_to_files_dir() {
 
     // Verify file went to files source dir with the same name
     let source_path = fix.dir.path().join("files").join("myscript");
-    assert!(source_path.exists(), "source file should exist in files dir");
+    assert!(
+        source_path.exists(),
+        "source file should exist in files dir"
+    );
     assert_eq!(
         fs::read_to_string(&source_path).unwrap(),
         "#!/bin/sh\necho hello"
@@ -1210,7 +1230,10 @@ fn apply_shared_target_no_collision_between_dotfiles_and_files() {
     fix.nostos().arg("apply").assert().success();
 
     // Dotfiles source "config/starship.toml" → target ".config/starship.toml" (dot-prepend)
-    assert_eq!(fix.read_target(".config/starship.toml"), "# dotfiles version");
+    assert_eq!(
+        fix.read_target(".config/starship.toml"),
+        "# dotfiles version"
+    );
     // Files source "config/starship.toml" → target "config/starship.toml" (verbatim)
     assert_eq!(fix.read_target("config/starship.toml"), "# files version");
 }
@@ -1264,10 +1287,7 @@ fn track_shared_target_routes_dotfile_and_plain_to_correct_sections() {
         plain_source.exists(),
         "plain file should route to files/config/starship.toml"
     );
-    assert_eq!(
-        fs::read_to_string(&plain_source).unwrap(),
-        "# from files"
-    );
+    assert_eq!(fs::read_to_string(&plain_source).unwrap(), "# from files");
 
     // Cross-contamination check: dotfiles didn't get the plain file, files didn't get the dotfile
     assert!(
@@ -1275,7 +1295,10 @@ fn track_shared_target_routes_dotfile_and_plain_to_correct_sections() {
         "files section should NOT contain .config/starship.toml"
     );
     assert!(
-        !fix.dir.path().join("dotfiles/.config/starship.toml").exists(),
+        !fix.dir
+            .path()
+            .join("dotfiles/.config/starship.toml")
+            .exists(),
         "dotfiles section should NOT contain .config/starship.toml with leading dot"
     );
 }
@@ -1310,9 +1333,7 @@ impl SyncFixture {
 
         // Seed with nostos.toml and a dotfile
         let target = home.to_string_lossy().to_string();
-        let config = format!(
-            "[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n"
-        );
+        let config = format!("[dotfiles]\nsource = \"dotfiles/\"\ntarget = '{target}'\n");
         fs::write(local.join("nostos.toml"), config).unwrap();
         fs::create_dir_all(local.join("dotfiles")).unwrap();
         fs::write(local.join("dotfiles").join("bashrc"), "# initial").unwrap();
@@ -1441,7 +1462,10 @@ target = '{target}'
 
     // Create both base and platform-override source files
     fix.add_source("bashrc", "# base bashrc");
-    let platform_dir = fix.dir.path().join(format!("dotfiles/platforms/{platform}"));
+    let platform_dir = fix
+        .dir
+        .path()
+        .join(format!("dotfiles/platforms/{platform}"));
     fs::create_dir_all(&platform_dir).unwrap();
     fs::write(platform_dir.join("bashrc"), "# platform bashrc").unwrap();
 
@@ -1466,8 +1490,7 @@ target = '{target}'
     assert_eq!(platform_content, "# platform edited");
 
     // Base should be untouched
-    let base_content =
-        fs::read_to_string(fix.dir.path().join("dotfiles").join("bashrc")).unwrap();
+    let base_content = fs::read_to_string(fix.dir.path().join("dotfiles").join("bashrc")).unwrap();
     assert_eq!(base_content, "# base bashrc");
 }
 
@@ -1553,11 +1576,7 @@ fn sync_pulls_remote_commits() {
     );
     run_git(&second, &["config", "user.email", "test@example.com"]);
     run_git(&second, &["config", "user.name", "Test"]);
-    fs::write(
-        second.join("dotfiles").join("gitconfig"),
-        "# from remote",
-    )
-    .unwrap();
+    fs::write(second.join("dotfiles").join("gitconfig"), "# from remote").unwrap();
     run_git(&second, &["add", "--all"]);
     run_git(&second, &["commit", "-m", "remote commit"]);
     run_git(&second, &["push"]);
@@ -1683,10 +1702,8 @@ fn track_directory_imports_new_files_into_source_and_state() {
         .stdout(predicate::str::contains("1 new"));
 
     // Verify the new file was imported into source tree with dot stripped
-    let imported = fs::read_to_string(
-        fix.dir.path().join("dotfiles/config/nvim/init.lua"),
-    )
-    .unwrap();
+    let imported =
+        fs::read_to_string(fix.dir.path().join("dotfiles/config/nvim/init.lua")).unwrap();
     assert_eq!(imported, "-- nvim config");
 
     // Verify subsequent apply deploys it back (i.e., state was registered)
@@ -1763,7 +1780,9 @@ fn track_directory_applies_dot_strip_inversion_for_new_dotfiles() {
 
     // Verify dot was stripped: lands in dotfiles/config/alacritty/alacritty.toml
     let imported = fs::read_to_string(
-        fix.dir.path().join("dotfiles/config/alacritty/alacritty.toml"),
+        fix.dir
+            .path()
+            .join("dotfiles/config/alacritty/alacritty.toml"),
     )
     .unwrap();
     assert_eq!(imported, "[font]\nsize = 14");
@@ -1788,7 +1807,9 @@ fn track_directory_prints_correct_summary_with_mixed_counts() {
         .arg(&target_dir)
         .assert()
         .success()
-        .stdout(predicate::str::contains("Tracked 3 files: 2 updated, 1 new"));
+        .stdout(predicate::str::contains(
+            "Tracked 3 files: 2 updated, 1 new",
+        ));
 }
 
 #[test]
@@ -1815,4 +1836,65 @@ fn track_prune_flag_ignored_for_single_file() {
     // Source was updated
     let source = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
     assert_eq!(source, "# edited");
+}
+
+#[test]
+fn track_directory_without_prune_blocks_on_orphans() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original bash");
+    fix.add_source("gitconfig", "# original git");
+
+    fix.nostos().arg("apply").assert().success();
+
+    fs::remove_file(fix.target_dir().join(".gitconfig")).unwrap();
+    fix.add_target(".bashrc", "# edited bash");
+
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg(&target_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dotfiles/gitconfig"));
+
+    let bash_src = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(bash_src, "# original bash");
+}
+
+#[test]
+fn track_directory_with_prune_removes_orphans_and_proceeds() {
+    let fix = TestFixture::new().with_default_config();
+    fix.add_source("bashrc", "# original bash");
+    fix.add_source("gitconfig", "# original git");
+
+    fix.nostos().arg("apply").assert().success();
+
+    fs::remove_file(fix.target_dir().join(".gitconfig")).unwrap();
+    fix.add_target(".bashrc", "# edited bash");
+
+    let target_dir = fix.target_dir();
+    fix.nostos()
+        .arg("track")
+        .arg("--prune")
+        .arg(&target_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pruned 1 orphaned source files"))
+        .stdout(predicate::str::contains(
+            "Tracked 1 files: 1 updated, 0 new",
+        ));
+
+    assert!(!fix.dir.path().join("dotfiles/gitconfig").exists());
+    let bash_src = fs::read_to_string(fix.dir.path().join("dotfiles/bashrc")).unwrap();
+    assert_eq!(bash_src, "# edited bash");
+
+    let state = State::load_from(&state_path(fix.dir.path())).unwrap();
+    assert!(!state.applied.contains_key(".gitconfig"));
+    assert!(state.applied.contains_key(".bashrc"));
+
+    fix.nostos()
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date"));
 }


### PR DESCRIPTION
Closes #69

## Summary

Implements orphan detection during recursive directory track:

- After target walk, walks the corresponding source subtree to find orphans (source files with no matching target)
- Orphan detection is scoped to the tracked subtree only
- **Without `--prune`**: orphans block the operation, prints the list to stderr, exits non-zero
- **With `--prune`**: removes orphan source files and their state entries, then proceeds with normal track
- `--prune` is silently ignored for single-file track

## Tests

- E2E test: directory track blocked by orphans (without `--prune`)
- E2E test: orphans pruned and track proceeds (with `--prune`)
- All existing tests pass