### PR TITLE
Show tilde-prefixed paths in plan/apply/track output

### DIFF
--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -1,11 +1,48 @@
 use crate::reconcile::dotfiles::DotfileAction;
 use crate::reconcile::ApplyReport;
+use std::path::{Path, PathBuf};
 
-/// Format a target path for display, showing just the filename.
-pub fn display_target(path: &std::path::Path) -> String {
-    path.file_name()
-        .map(|f| f.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.display().to_string())
+/// Format a path for display.
+///
+/// If the path is under the user's home directory, the home prefix is
+/// replaced with `~` and the remainder is rendered with forward slashes
+/// (e.g. `/home/ben/.config/git/config` → `~/.config/git/config`). If the
+/// path is exactly the home directory, returns `~`. Otherwise returns the
+/// absolute path verbatim.
+pub fn display_path(path: &Path) -> String {
+    display_path_with_home(path, home_dir().as_deref())
+}
+
+fn display_path_with_home(path: &Path, home: Option<&Path>) -> String {
+    if let Some(home) = home
+        && !home.as_os_str().is_empty()
+    {
+        if path == home {
+            return "~".to_string();
+        }
+        if let Ok(rel) = path.strip_prefix(home) {
+            let rel_str = rel
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join("/");
+            if rel_str.is_empty() {
+                return "~".to_string();
+            }
+            return format!("~/{rel_str}");
+        }
+    }
+    path.display().to_string()
+}
+
+/// Resolve the user's home directory the same way the rest of the codebase
+/// does: `HOME` env first (so tests can override it cross-platform), then
+/// `dirs::home_dir()` as a fallback.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(dirs::home_dir)
 }
 
 /// Print plan-mode actions for a single section (dotfiles or files).
@@ -13,24 +50,24 @@ pub fn print_plan_actions(actions: &[DotfileAction]) {
     for action in actions {
         match action {
             DotfileAction::NewFile { target, .. } => {
-                println!("  {} — new file", display_target(target));
+                println!("  {} — new file", display_path(target));
             }
             DotfileAction::UpToDate { target } => {
-                println!("  {} — up to date", display_target(target));
+                println!("  {} — up to date", display_path(target));
             }
             DotfileAction::CleanUpdate { target, .. } => {
-                println!("  {} — clean update (repo changed)", display_target(target));
+                println!("  {} — clean update (repo changed)", display_path(target));
             }
             DotfileAction::LocalModification { target } => {
                 println!(
                     "  {} — local modification (not in repo)",
-                    display_target(target)
+                    display_path(target)
                 );
             }
             DotfileAction::Conflict { target, .. } => {
                 println!(
                     "  {} — conflict (both sides changed, will back up)",
-                    display_target(target)
+                    display_path(target)
                 );
             }
         }
@@ -42,27 +79,27 @@ pub fn print_apply_actions(actions: &[DotfileAction]) {
     for action in actions {
         match action {
             DotfileAction::NewFile { target, .. } => {
-                println!("  ✓ Copied → {}", target.display());
+                println!("  ✓ Copied → {}", display_path(target));
             }
             DotfileAction::UpToDate { target } => {
-                println!("  ✓ {} — up to date", display_target(target));
+                println!("  ✓ {} — up to date", display_path(target));
             }
             DotfileAction::CleanUpdate { target, .. } => {
-                println!("  ✓ Updated → {}", target.display());
+                println!("  ✓ Updated → {}", display_path(target));
             }
             DotfileAction::LocalModification { target } => {
                 println!(
                     "  ⚠ {} — local modification, skipped",
-                    display_target(target)
+                    display_path(target)
                 );
             }
             DotfileAction::Conflict { target, backup, .. } => {
                 println!(
                     "  ⚠ Backed up {} → {}",
-                    display_target(target),
-                    backup.display()
+                    display_path(target),
+                    display_path(backup)
                 );
-                println!("  ✓ Updated → {}", target.display());
+                println!("  ✓ Updated → {}", display_path(target));
             }
         }
     }
@@ -96,5 +133,89 @@ pub fn print_pending_phases(report: &ApplyReport) {
         if let Some(ref reason) = phase.skipped_reason {
             println!("⚠ {reason}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn under_home_substitutes_tilde() {
+        let home = PathBuf::from("/home/ben");
+        let path = PathBuf::from("/home/ben/.config/git/config");
+        assert_eq!(
+            display_path_with_home(&path, Some(&home)),
+            "~/.config/git/config"
+        );
+    }
+
+    #[test]
+    fn target_equal_to_home_renders_as_tilde() {
+        let home = PathBuf::from("/home/ben");
+        assert_eq!(display_path_with_home(&home, Some(&home)), "~");
+    }
+
+    #[test]
+    fn outside_home_returns_absolute_path() {
+        let home = PathBuf::from("/home/ben");
+        let path = PathBuf::from("/etc/hosts");
+        assert_eq!(display_path_with_home(&path, Some(&home)), "/etc/hosts");
+    }
+
+    #[test]
+    fn home_unset_returns_absolute_path() {
+        let path = PathBuf::from("/home/ben/.bashrc");
+        assert_eq!(
+            display_path_with_home(&path, None),
+            "/home/ben/.bashrc"
+        );
+    }
+
+    #[test]
+    fn empty_home_treated_as_unset() {
+        let home = PathBuf::from("");
+        let path = PathBuf::from("/home/ben/.bashrc");
+        assert_eq!(
+            display_path_with_home(&path, Some(&home)),
+            "/home/ben/.bashrc"
+        );
+    }
+
+    /// Path-component prefix safety: `/home/benny/...` must NOT match
+    /// `HOME=/home/ben`. Using `Path::strip_prefix` (component-based) instead
+    /// of string prefix matching is what makes this safe.
+    #[test]
+    fn sibling_directory_with_shared_string_prefix_not_substituted() {
+        let home = PathBuf::from("/home/ben");
+        let path = PathBuf::from("/home/benny/.bashrc");
+        assert_eq!(
+            display_path_with_home(&path, Some(&home)),
+            "/home/benny/.bashrc"
+        );
+    }
+
+    #[test]
+    fn nested_path_renders_with_forward_slashes() {
+        let home = PathBuf::from("/Users/ben");
+        let path = PathBuf::from("/Users/ben/.config/nvim/init.lua");
+        assert_eq!(
+            display_path_with_home(&path, Some(&home)),
+            "~/.config/nvim/init.lua"
+        );
+    }
+
+    /// On Windows, paths use backslash components but we render with
+    /// forward slashes for cross-platform consistency (matches the
+    /// forward-slash logical key invariant in CONTEXT.md).
+    #[cfg(windows)]
+    #[test]
+    fn windows_path_under_userprofile_uses_forward_slashes() {
+        let home = PathBuf::from(r"C:\Users\ben");
+        let path = PathBuf::from(r"C:\Users\ben\.config\git\config");
+        assert_eq!(
+            display_path_with_home(&path, Some(&home)),
+            "~/.config/git/config"
+        );
     }
 }

--- a/src/cli/track.rs
+++ b/src/cli/track.rs
@@ -188,7 +188,7 @@ fn track_directory(
 
     let total = updated + new_count;
     if total == 0 && pruned == 0 && errors.is_empty() {
-        println!("No files to track in {}", target_dir.display());
+        println!("No files to track in {}", crate::cli::report::display_path(target_dir));
         if skipped_symlinks > 0 {
             println!("Skipped {skipped_symlinks} symlinks");
         }
@@ -566,8 +566,8 @@ fn do_track_managed(
 
     println!(
         "Tracked {} → {}",
-        target_path.display(),
-        source_path.display()
+        crate::cli::report::display_path(target_path),
+        crate::cli::report::display_path(&source_path)
     );
     Ok(ExitCode::SUCCESS)
 }
@@ -588,7 +588,11 @@ fn copy_and_print_guidance(
         .map_err(|e| anyhow::anyhow!("cannot copy {}: {e}", target_path.display()))?;
 
     let rel_dest = dest.strip_prefix(repo_root).unwrap_or(dest).display();
-    println!("Copied {} → {}", target_path.display(), dest.display());
+    println!(
+        "Copied {} → {}",
+        crate::cli::report::display_path(target_path),
+        crate::cli::report::display_path(dest)
+    );
     println!();
     println!("Add to nostos.toml (file is not yet managed until you do):");
     println!("  # The base source directory already covers this file.");


### PR DESCRIPTION
## Summary

`nostos plan` / `apply` / `track` previously printed only the file name of each target — e.g. `config — new file` — which is ambiguous when multiple managed files share a basename (`.config/git/config` vs `.ssh/config` vs `.config/fish/config`). Apply mode was also inconsistent: `NewFile` / `CleanUpdate` printed the full absolute path while other variants printed bare filenames.

This change replaces both forms with a tilde-prefixed home-relative path:

```
Dotfiles:
  ~/.config/git/config — new file
  ~/.config/starship.toml — up to date
  ~/.bashrc — clean update (repo changed)
```

## Design

A new `display_path()` helper in `src/cli/report.rs`:

- Substitutes `$HOME` with `~` when the path is under it (`/home/ben/.config/git/config` → `~/.config/git/config`).
- Uses `Path::strip_prefix` for **component-based** matching, so `HOME=/home/ben` does **not** mangle `/home/benny/...`.
- Renders the relative segment with forward slashes for cross-platform consistency (matches the forward-slash logical key invariant in `CONTEXT.md`).
- Falls back to the absolute path when the target is outside `$HOME`, when `HOME` is unset, or when `HOME` is empty.
- Resolves home via `HOME` env first, then `dirs::home_dir()` — same pattern as `src/cli/init.rs`, so Windows (where `HOME` isn't set by default) is covered by the `dirs::home_dir()` fallback (which reads `USERPROFILE`).

## Scope

Applied to:

- `print_plan_actions` — all five action variants
- `print_apply_actions` — all five variants, including the backup path in the `Conflict` arm (so `~/.bashrc.nostos-backup-…` instead of an absolute path)
- `track.rs` user-facing success/info prints: "No files to track in …", "Tracked X → Y", "Copied X → Y"

**Not** touched:

- Error / diagnostic messages — full absolute paths remain better for debugging and copy-paste.
- The `nostos.toml` snippet emitted by `track` — that's TOML content, not a path to a real location.

## Alternatives considered

A tree-style listing grouped by directory was discussed and deferred to #75. The flat list keeps the one-line-per-action invariant intact (so `nostos plan | grep new` still works) and reads naturally for apply's verb-phrase output.

## Tests

Seven new unit tests in `src/cli/report.rs` exercise the helper:

- under home → tilde substitution
- target equals home → `~`
- outside home → absolute path
- `HOME` unset → absolute path
- `HOME` empty string → absolute path
- sibling directory with shared string prefix (`/home/benny` under `HOME=/home/ben`) → absolute path (verifies component-based matching)
- nested path renders with forward slashes
- Windows path under `USERPROFILE` renders with forward slashes (`#[cfg(windows)]`)

Full suite (215 tests) green, `cargo clippy --all-targets` clean.

## Related

- Tree-style listing: #75 (follow-up)
